### PR TITLE
fix: make homepage cta not visible in mobile and card works on light mode

### DIFF
--- a/src/components/UpcomingPaper.tsx
+++ b/src/components/UpcomingPaper.tsx
@@ -33,7 +33,7 @@ export default function PaperCard({ subject, slots }: PaperCardProps) {
 
         router.push(`/catalogue?${queryParams.toString()}`);
       }}
-      className="cursor-pointer rounded-md border-2 border-[#453D60] bg-[#15121c] text-white shadow-lg hover:bg-[#292139]"
+      className="cursor-pointer rounded-sm border-2 border-[#734DFF] bg-[#FFFFFF] text-black shadow-lg hover:bg-[#EFEAFF] dark:border-[#36266D] dark:bg-[#171720] dark:text-white hover:dark:bg-[#262635]"
     >
       {/* Course Code */}
       <div className="border-b-2 border-[#453D60] p-2">

--- a/src/components/screens/Hero.tsx
+++ b/src/components/screens/Hero.tsx
@@ -5,13 +5,13 @@ import Link from "next/link";
 
 const Hero = () => {
   return (
-    <div className="flex flex-col justify-between min-h-[calc(100vh-85px)]">
+    <div className="flex flex-col justify-between ">
       <h1 className="vipnabd mx-auto my-8 text-center text-3xl font-extrabold">
         Built by Students for Students
       </h1>
       <SearchBar />
       <StoredPapers />
-      <div className="flex flex-col items-center whitespace-nowrap text-center">
+      <div className="hidden md:flex flex-col items-center whitespace-nowrap text-center">
         <h1 className="play text-md">Learn More</h1>
         <Link
           href="#hero"

--- a/src/components/screens/Hero.tsx
+++ b/src/components/screens/Hero.tsx
@@ -11,7 +11,7 @@ const Hero = () => {
       </h1>
       <SearchBar />
       <StoredPapers />
-      <div className="hidden md:flex flex-col items-center whitespace-nowrap text-center">
+      <div className="hidden lg:flex flex-col items-center whitespace-nowrap text-center">
         <h1 className="play text-md">Learn More</h1>
         <Link
           href="#hero"


### PR DESCRIPTION
Fix 2end part of #150 and hide cta on mobile/tablet #153