### PR TITLE
fix: cookoff header line

### DIFF
--- a/src/components/CookoffBanner.tsx
+++ b/src/components/CookoffBanner.tsx
@@ -17,11 +17,10 @@ export default function CookoffBanner() {
             className="md:hidden"
           />
 
-          <span className="hidden md:block">
-            Marking 10 years of coding excellence, CookOff is back as
-            graVITas&apos; biggest coding challenge – test your skills and make
-            history!
-          </span>
+            <span className="hidden md:block">
+            10 Years. Hundreds of Coders. One Champion.
+            CookOff, the biggest competitive coding challenge of graVITas is back!
+            </span>
 
           <Link
             href="https://gravitas.vit.ac.in/events/bdfcebea-c141-4a61-ac73-61dec96c08f4"


### PR DESCRIPTION
### **Purpose:**
Headline for CookOff 10.0
### **Showcase:** 
<img width="1914" height="313" alt="image" src="https://github.com/user-attachments/assets/2e3c86c3-0183-4e0a-915e-3decafbaebb8" />
