### PR TITLE
mobile-carousel-fixes

### DIFF
--- a/src/components/PinnedPapersCarousel.tsx
+++ b/src/components/PinnedPapersCarousel.tsx
@@ -164,13 +164,16 @@ function PinnedPapersCarousel({
           plugins={plugins}
           className="w-full"
         >
-          {displayPapers.length >= 8 &&
-          <div
-            className={`relative mt-4 flex justify-end gap-4`}
-          >
-            <CarouselPrevious className="relative" />
-            <CarouselNext className="relative" />
-          </div>}
+          {(() => {
+      const totalItems = displayPapers.length + 1;
+      const needsNav = totalItems > chunkSize;
+      return needsNav ? (
+        <div className="relative mt-4 flex justify-end gap-4">
+          <CarouselPrevious className="relative" />
+          <CarouselNext className="relative" />
+        </div>
+      ) : null;
+    })()}
           <CarouselContent>
             {isLoading ? (
               <CarouselItem

--- a/src/components/screens/Hero.tsx
+++ b/src/components/screens/Hero.tsx
@@ -12,7 +12,7 @@ const Hero = () => {
       <div className="mt-5 px-6">
         <SearchBar />
       </div>
-      <p className="my-8 hidden text-center font-play text-lg font-semibold md:block">
+      <p className="my-8 text-center font-play text-lg font-semibold">
         Pinned Subjects
       </p>
       <PinnedPapersCarousel carouselType="users"/>


### PR DESCRIPTION
fixes: #362 

Fix: Pinned Subjects Carousel & Header on Small Screens

Issue

  On mobile/tablet:
  

-   Carousel arrows were missing when subjects exceeded chunk size.
-   "Pinned Subjects" header was hidden, making it hard to distinguish from Upcoming Papers.

Fix

-   Updated logic to show arrows when displayPapers.length + 1 > chunkSize.
-   Made "Pinned Subjects" header always visible.

Changes

  Hero.tsx
  

-     Made "Pinned Subjects" heading always visible.
-     Fixed conditional rendering of navigation arrows based on total items instead of hard-coded thresholds.

Result

-   Consistent carousel navigation across devices.   
-   Clearer section distinction in the Hero.