### PR TITLE
fix : removed extra projects from footer

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -100,14 +100,6 @@ export default function Footer() {
           <Link href="https://gravitas.codechefvit.com" target="_blank">CookOff</Link>
           <Link href="https://gravitas.codechefvit.com" target="_blank">Clueminati</Link>
         </div>
-<div className="flex flex-col gap-2 text-black dark:text-white md:items-start lg:text-left">
-  <h3 className="font-jost text-2xl font-semibold">Our Projects</h3>
-  <Link href="https://papers.codechefvit.com">Papers</Link>
-  <Link href="https://contactify.codechefvit.com">Contactify</Link>
-  <Link href="https://ffcs.codechefvit.com">FFCS-iniator</Link>
-</div>
-
-
         {/* Projects */}
         <div className="flex w-full flex-col gap-2 text-black dark:text-white  lg:w-[20%]">
           <h3 className="font-jost text-xl font-semibold">Our Projects</h3>


### PR DESCRIPTION
## 📌 Purpose
Cleaned up the footer section to remove duplicate "Our Projects" columns.

Previously, there were two identical "Our Projects" sections in the footer, which was unnecessary and cluttered the UI. This PR removes the extra section to improve clarity and maintain design consistency.

## 🖼️ Showcase

Before:
<img width="311" height="215" alt="image" src="https://github.com/user-attachments/assets/7b4b509f-6f6f-4749-be96-3adcdb1d2039" />

After:
<img width="920" height="224" alt="image" src="https://github.com/user-attachments/assets/7ba4c725-ee4e-49e9-9ace-7de4666e337c" />

## 🔧 Changes
- Removed the extra "Our Projects" column in the footer.
