### PR TITLE
fix: add conditional rendering to render pagination only when totalPages >1.

### DIFF
--- a/src/components/CatalogueContent.tsx
+++ b/src/components/CatalogueContent.tsx
@@ -487,27 +487,29 @@ const CatalogueContent = () => {
                 ))
               )}
             </div>
-            <div className="mt-8 flex items-center justify-center gap-4">
-              <Button
-                variant="outline"
-                disabled={currentPage === 1}
-                onClick={() => setCurrentPage((prev) => prev - 1)}
-              >
-                Previous
-              </Button>
+            {totalPages > 1 && (
+              <div className="mt-8 flex items-center justify-center gap-4">
+                <Button
+                  variant="outline"
+                  disabled={currentPage === 1}
+                  onClick={() => setCurrentPage((prev) => prev - 1)}
+                >
+                  Previous
+                </Button>
 
-              <span className="text-gray-700 dark:text-gray-300">
-                Page {currentPage} of {totalPages}
-              </span>
+                <span className="text-gray-700 dark:text-gray-300">
+                  Page {currentPage} of {totalPages}
+                </span>
 
-              <Button
-                variant="outline"
-                disabled={currentPage === totalPages}
-                onClick={() => setCurrentPage((prev) => prev + 1)}
-              >
-                Next
-              </Button>
-            </div>
+                <Button
+                  variant="outline"
+                  disabled={currentPage === totalPages}
+                  onClick={() => setCurrentPage((prev) => prev + 1)}
+                >
+                  Next
+                </Button>
+              </div>
+            )}
           </div>
         ) : (
           <Error


### PR DESCRIPTION
## 📌 Purpose
This PR adds a simple `conditional check` to render the `pagination` ui only when there are more than one `total` pages.  


---

## Corresponding issue: closes #370 
---


## 🖼️ Showcase
<img width="1865" height="892" alt="Screenshot from 2025-10-06 12-25-33" src="https://github.com/user-attachments/assets/ff0ad70d-0897-4a42-956a-76041562023f" />

Catalogue with only one **total page**.

<img width="1865" height="930" alt="Screenshot from 2025-10-06 12-25-52" src="https://github.com/user-attachments/assets/4b9524e7-2978-4f10-b3de-d15b04ab95ca" />

Catalogue with more than one **total page**.


---

## 🔧 Changes
- added a conditional check to render the pagination ui in `catalogue.tsx`. the conditional check is: `totalPages > 1`.

---

## ➕ Additional Notes
None.
