### PR TITLE
feat : Full Keyboard Navigation Support for Subject Search Bars #376

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -5428,8 +5428,8 @@ snapshots:
       '@typescript-eslint/parser': 8.45.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -5448,7 +5448,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -5459,22 +5459,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.45.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5485,7 +5485,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/src/components/Searchbar/pinned-searchbar.tsx
+++ b/src/components/Searchbar/pinned-searchbar.tsx
@@ -15,10 +15,12 @@ import { IUpcomingPaper } from "@/interface";
 function PinnedSearchBar({
   initialSubjects,
   setDisplayPapers,
+  displayPapers,
   filtersNotPulled,
 }: {
   initialSubjects: ICourseWithCount[];
   setDisplayPapers: React.Dispatch<React.SetStateAction<IUpcomingPaper[]>>; 
+  displayPapers : IUpcomingPaper[];
   filtersNotPulled?: () => void;
 }) {
   const router = useRouter();
@@ -31,7 +33,7 @@ function PinnedSearchBar({
   const [fuzzy, setFuzzy] = useState(
     () => new Fuse<ICourseWithCount>([], { keys: ["name"], threshold: 0.3 }),
   );
-
+  const [highlightedIndex, setHighlightedIndex] = useState<number>(-1);
   useEffect(() => {
     if (initialSubjects && initialSubjects.length > 0) {
       setFuzzy(new Fuse(initialSubjects, { keys: ["name"], threshold: 0.3 }));
@@ -88,13 +90,13 @@ function PinnedSearchBar({
     };
   }, []);
 
-  const handlePinToggle = () => {
+  const handlePinToggle = (searchTextOverride? : string) => {
     const current = !pinned;
     setPinned(current);
-
+    const subject : string = (searchTextOverride ?? searchText).toString().trim();
     if (
-      searchText.trim() === "" ||
-      !initialSubjects.find((s) => s.name === searchText)
+      subject.trim() === "" ||
+      !initialSubjects.find((s) => s.name === subject)
     ) {
       return;
     }
@@ -102,10 +104,17 @@ function PinnedSearchBar({
     const saved = JSON.parse(
       localStorage.getItem("userSubjects") ?? "[]",
     ) as string[];
-    const updated = current
-      ? [...new Set([...saved, searchText])]
-      : saved.filter((s) => s !== searchText);
-  
+
+    let updated: string[] = [];
+
+    if (saved.includes(subject)) {
+      updated = saved.filter((s) => s !== subject);
+      setPinned(false);
+    } else {
+      updated = [...new Set([...saved, subject])];
+      setPinned(true);
+    }
+    
 
     if (updated.length === 0) {
       setShowControls(false);
@@ -116,18 +125,17 @@ function PinnedSearchBar({
     localStorage.setItem("userSubjects", JSON.stringify(updated));
 
     setDisplayPapers((prev) => {
-      if (current) {
-        if (!prev.find((paper) => paper.subject === searchText)) {
-          return [...prev, { subject: searchText, slots: [] }];
-        }
-        return prev;
+      const isAlreadyPinned = prev.find((paper) => paper.subject === subject);
+      if (!isAlreadyPinned) {
+        return [...prev, { subject, slots: [] }];
       } else {
-        return prev.filter((paper) => paper.subject !== searchText);
+        return prev.filter((paper) => paper.subject !== subject);
       }
     });
 
     setSearchText("");
     setPinned(false);
+    setHighlightedIndex(-1);
   };
 
   useEffect(() => {
@@ -186,6 +194,24 @@ function PinnedSearchBar({
                   className={`text-md w-full rounded-lg bg-[#B2B8FF] px-4 py-6 pr-10 font-play tracking-wider text-black shadow-sm ring-0 placeholder:text-black focus:outline-none focus:ring-0 dark:bg-[#7480FF66] dark:text-white placeholder:dark:text-white ${
                     suggestions.length > 0 ? "rounded-b-none" : ""
                   }`}
+                  onKeyDown={(e) => {
+                    if(suggestions.length == 0 && searchText.trim() == "") return;
+                    if(e.key == 'ArrowDown'){
+                      e.preventDefault();
+                      setHighlightedIndex((curr) => (curr + 1) % suggestions.length);
+                    }
+                    else if(e.key == 'ArrowUp'){
+                      e.preventDefault();
+                      setHighlightedIndex((curr) => (curr - 1 + suggestions.length) % suggestions.length);
+                    }
+                    else if(e.key == 'Enter'){
+                      e.preventDefault();
+                      if(suggestions.length > 0 && highlightedIndex >=0 && suggestions[highlightedIndex] != undefined){
+                        handlePinToggle(suggestions[highlightedIndex]);
+                        setSuggestions([]);
+                      }
+                    }
+                  }}
                 />
                 <div className="absolute inset-y-0 right-3 flex items-center">
                   <Search className="h-5 w-5 text-black dark:text-white" />
@@ -202,7 +228,10 @@ function PinnedSearchBar({
                       <li
                         key={index}
                         onClick={() => handleSelectSuggestion(suggestion)}
-                        className="cursor-pointer truncate p-2 hover:bg-gray-100 dark:hover:bg-gray-800"
+                        className={`flex cursor-pointer items-center rounded p-2 
+                        ${index === highlightedIndex
+                          ? "bg-gray-200 dark:bg-gray-800"
+                          : "hover:bg-gray-200 dark:hover:bg-gray-800"}`}
                       >
                         {suggestion}
                       </li>

--- a/src/components/Searchbar/searchbar-child.tsx
+++ b/src/components/Searchbar/searchbar-child.tsx
@@ -21,6 +21,7 @@ function SearchBarChild({
   const [fuzzy, setFuzzy] = useState(
     () => new Fuse<ICourseWithCount>([], { keys: ["name"], threshold: 0.3 }),
   );
+  const [highlightedIndex, setHighlightedIndex] = useState<number>(-1);
 
   useEffect(() => {
     if (initialSubjects && initialSubjects.length > 0) {
@@ -47,9 +48,10 @@ function SearchBarChild({
 
   const handleSelectSuggestion = (suggestion: ICourseWithCount) => {
     router.push(`/catalogue?subject=${encodeURIComponent(suggestion.name)}`);
-    setSearchText(suggestion.name);
+    setSearchText("");
     setSuggestions([]);
     filtersNotPulled?.();
+    setHighlightedIndex(-1);
   };
 
   const handleClickOutside = (event: MouseEvent) => {
@@ -86,6 +88,38 @@ function SearchBarChild({
             onChange={handleSearchChange}
             placeholder="Search by subject..."
             className={`text-md rounded-lg bg-[#B2B8FF] px-4 py-6 pr-10 font-play tracking-wider text-black shadow-sm ring-0 placeholder:text-black focus:outline-none focus:ring-0 dark:bg-[#7480FF66] dark:text-white placeholder:dark:text-white ${suggestions.length > 0 ? "rounded-b-none" : ""}`}
+            onKeyDown={(e) => {
+              if (suggestions.length === 0) return;
+              if (e.key === "ArrowDown") {
+                e.preventDefault();
+                setHighlightedIndex((prev) => (prev + 1) % suggestions.length);
+              } else if (e.key === "ArrowUp") {
+                e.preventDefault();
+                setHighlightedIndex((prev) => (prev - 1 + suggestions.length) % suggestions.length);
+              } else if (e.key === "Enter") {
+                e.preventDefault();
+                if (highlightedIndex >= 0 && highlightedIndex < suggestions.length && suggestions[highlightedIndex] !== undefined) {
+                  handleSelectSuggestion(suggestions[highlightedIndex]);
+                } else {
+                  router.push(`/catalogue?subject=${encodeURIComponent(searchText)}`);
+                  setSuggestions([]);
+                }
+              } else if (e.key === "Tab") {
+                e.preventDefault();
+                if(highlightedIndex == -1){
+                  if (suggestions.length > 0 && suggestions[0] != undefined) {
+                    setSearchText(suggestions[0].name || "");
+                    setSuggestions([]);
+                  }
+                }else{
+                  if (highlightedIndex >= 0 && highlightedIndex < suggestions.length && suggestions[highlightedIndex] !== undefined) {
+                    setSearchText(suggestions[highlightedIndex].name || "");
+                    setHighlightedIndex(-1);
+                    setSuggestions([]);
+                  }
+                }
+              }
+            }}
           />
           <button
             type="submit"
@@ -100,12 +134,15 @@ function SearchBarChild({
               className={`absolute z-20 w-full max-w-xl overflow-y-auto rounded-md rounded-t-none border border-t-0 bg-white text-center shadow-lg dark:bg-[#303771] md:mx-0`}
               style={{ maxHeight: "400px" }}
             >
-              {suggestions.map((suggestion) => (
+              {suggestions.map((suggestion : ICourseWithCount, index) => (
                 <li
                   key={suggestion._id}
                   onClick={() => handleSelectSuggestion(suggestion)}
-                  className="flex cursor-pointer items-center rounded p-2 hover:bg-gray-100 dark:hover:bg-gray-800"
-                >
+                  className={`flex cursor-pointer items-center rounded p-2 
+                  ${index === highlightedIndex
+                    ? "bg-gray-200 dark:bg-gray-800"
+                    : "hover:bg-gray-200 dark:hover:bg-gray-800"}`}
+                  >
                   <div
                     id="paper_count"
                     className="mr-4 flex h-8 w-8 items-center justify-center rounded-md bg-[#171720] text-xs font-semibold text-white"

--- a/src/components/Searchbar/searchbar.tsx
+++ b/src/components/Searchbar/searchbar.tsx
@@ -8,15 +8,17 @@ import { type IUpcomingPaper } from "@/interface";
 
 export default function SearchBar({
   type = "default",
+  displayPapers,
   setDisplayPapers,
 }: {
   type?: "default" | "pinned",
+  displayPapers?:IUpcomingPaper[]
   setDisplayPapers?: React.Dispatch<React.SetStateAction<IUpcomingPaper[]>> 
 }) {
   const { courses, loading, error, refetch } = useCourses();
 
-  return type === "pinned" && setDisplayPapers !== undefined ? (
-    <PinnedSearchBar initialSubjects={courses} setDisplayPapers={setDisplayPapers} />
+  return type === "pinned" && setDisplayPapers !== undefined && displayPapers !== undefined ? (
+    <PinnedSearchBar initialSubjects={courses} setDisplayPapers={setDisplayPapers} displayPapers={displayPapers} />
   ) : (
     <SearchBarChild initialSubjects={courses} />
   );

--- a/src/components/ui/PinnedModal.tsx
+++ b/src/components/ui/PinnedModal.tsx
@@ -98,7 +98,7 @@ const PinnedModal = ({triggerName = "Pin Subjects", page = "Navbar"} : {triggerN
           <DialogTitle className="font-normal">
             <div className="my-3 flex w-full flex-col items-center gap-2 text-sm">
               <div className="w-full">
-                <SearchBar type="pinned" setDisplayPapers={setDisplayPapers}/>
+                <SearchBar type="pinned" setDisplayPapers={setDisplayPapers} displayPapers={displayPapers}/>
               </div>
             </div>
             <div className="mt-4">
@@ -118,7 +118,6 @@ const PinnedModal = ({triggerName = "Pin Subjects", page = "Navbar"} : {triggerN
                           Unpin
                           <PinOff size={16}/>
                         </div>
-                        
                       </button>
                     </div>
                   ))


### PR DESCRIPTION
## 📌 Purpose
Add full keyboard navigation support and reliable pin/unpin functionality to the subject search bars.  
This PR improves UX by allowing users to navigate suggestions with arrow keys, select with Enter, and autocomplete with Tab, while ensuring pinned subjects and displayed papers update correctly.

## Corresponding issue: closes #376 

## 🖼️ Showcase

https://github.com/user-attachments/assets/491e8f29-a2a6-49b2-9a6c-1e0a1a6dbbfe

## 🔧 Changes
- Added keyboard event listeners (`onKeyDown`) to `SearchBarChild` and `PinnedSearchBar` components:
  - ArrowUp / ArrowDown for navigating suggestions
  - Enter for selecting a suggestion or submitting
  - Tab for auto-completing the first suggestion

## ➕ Additional Notes
- Handles both normal and pinned search bars consistently
- Minor styling tweaks for highlighted suggestion state