### PR TITLE
fix: show answer key tag in mobile view #371

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -97,7 +97,7 @@ const Card = ({ paper, onSelect, isSelected }: CardProps) => {
         </div>
       </Link>
 
-      <div className="hidden items-center justify-between gap-2 px-4 pb-4 font-play md:flex">
+      <div className="flex items-center justify-between gap-2 px-4 pb-4 font-play">
         <div className="flex items-center gap-2">
           <input
             checked={checked}


### PR DESCRIPTION
📌 **Purpose**

Fixes a critical bug where the "Answer Key" tag was invisible on mobile devices (viewport width ≤768px), even when the corresponding filter was active. This ensures mobile users can correctly identify papers with available answer keys.

Corresponding issue: closes #371

🖼️ **Showcase**

<img width="384" height="891" alt="Screenshot from 2025-10-07 16-31-40" src="https://github.com/user-attachments/assets/baaf3158-56b2-4da3-80fe-49b12c9fb305" />


🔧 **Changes**

- Modified CSS (removed hidden tag) to ensure the Answer Key tag (specifically the indicator/tick mark) remains visible in mobile viewports.  
- Adjusted media queries for the catalogue page component responsible for displaying filter tags.

➕ **Additional Notes**

- No known side effects.  
- The fix is purely a CSS adjustment for display visibility on smaller screens.  
- Reviewers should primarily check the catalogue page on a mobile device or by resizing the browser window to ensure the tag is now correctly visible.
