### PR TITLE
fix: prevent empty papers.zip download when no papers are selected

### DIFF
--- a/src/components/CatalogueContent.tsx
+++ b/src/components/CatalogueContent.tsx
@@ -212,13 +212,14 @@ const CatalogueContent = () => {
   );
 
   const handleDownloadSelected = useCallback(async () => {
+    if (selectedPapers.length === 0) {
+      toast.error("No papers selected for download.");
+      return;
+    }
     const zip = new JSZip();
     const uniquePapers = Array.from(
       new Set(selectedPapers.map((paper) => paper._id)),
     ).map((id) => selectedPapers.find((paper) => paper._id === id)) as IPaper[];
-    if (!uniquePapers) {
-      toast.error("No papers selected for download.");
-    }
     for (const paper of uniquePapers) {
       try {
         const response = await fetch(getSecureUrl(paper.file_url));
@@ -419,9 +420,9 @@ const CatalogueContent = () => {
             </div>
           </div>
 
-          
+
       {/* Select/Deselect/Download All Buttons */}
-      
+
       <div className="mb-8 flex w-full items-center justify-end gap-4">
         <SidebarButton onClick={handleSelectAll}>
           Select All


### PR DESCRIPTION
## 📌 Purpose

To prevent the download of empty "papers.zip" file when "Download Selected" is hit without any papers selected in any subject page.

---

## Corresponding issue: closes #382 

---

## 🖼️ Showcase
<img width="627" height="385" alt="image" src="https://github.com/user-attachments/assets/e2e8ba23-8a3f-4235-ac2c-71b96b3999b8" />
---

## 🔧 Changes
Fixed the bug by restructuring logic for checking empty selections. Earlier the `if` condition was wrong and the few lines above the condition didn't need to run before checking if there are no selections. So moved the condition up and fixed the logic.

---

