### PR TITLE
Feature/default open sidebar accordions

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -29,3 +29,6 @@ What problem does it solve, or what feature does it add?
 Examples of a good PR - 
 
 https://github.com/CodeChefVIT/papers-codechef/pull/247
+
+
+**Note:** Open all pull requests to `staging` branch

--- a/src/components/SidebarSection.tsx
+++ b/src/components/SidebarSection.tsx
@@ -24,7 +24,7 @@ const SidebarSection: React.FC<SidebarSectionProps> = ({
 }) => (
   <div className="flex w-full flex-col items-baseline justify-between border-b-2 border-[#36266d] px-[10px]">
     <Accordion className="w-full" type="single" collapsible>
-      <AccordionItem className="border-none no-underline" value="item-1">
+      <AccordionItem className="border-none no-underline" value="item-1" defaultValue="item-1">
         <AccordionTrigger className="w-full no-underline">
           <div className="font-play text-sm no-underline">{label}</div>
         </AccordionTrigger>


### PR DESCRIPTION
## 📌 Purpose
Sets all sidebar filter accordions to be open by default when users land on the catalog page, improving filter discoverability and user experience.

---

## Corresponding issue: closes #381 

---

## 🖼️ Showcase
<img width="327" height="722" alt="image" src="https://github.com/user-attachments/assets/afd10648-168c-4abf-afc4-37c8f75f8116" />


---

## 🔧 Changes
- Added `defaultValue="item-1"` prop to the `Accordion` component in `SidebarSection`
- All filter sections (Exams, Slots, Years, Semesters) now render expanded by default
- Users retain the ability to collapse any section if desired

---

## ➕ Additional Notes
- [x] Verified all accordions are open on initial catalog page load
- [x] Confirmed accordions can still be collapsed individually
- [x] Tested that filtering functionality works correctly with expanded accordions
- [x] Closes #381  