### PR TITLE
Fix: Zoom level isn't remembered when I exist full screen #367

### DIFF
--- a/src/components/pdfViewer.tsx
+++ b/src/components/pdfViewer.tsx
@@ -11,7 +11,7 @@ import ShareButton from "./ShareButton";
 import Loader from "./ui/loader";
 import { FaGreaterThan, FaLessThan } from "react-icons/fa6";
 
-pdfjs.GlobalWorkerOptions.workerSrc = 
+pdfjs.GlobalWorkerOptions.workerSrc =
   "https://cdnjs.cloudflare.com/ajax/libs/pdf.js/4.8.69/pdf.worker.min.mjs";
 
 interface PdfViewerProps {
@@ -159,26 +159,14 @@ export default function PdfViewer({ url, name }: PdfViewerProps) {
   }, []);
 
   useEffect(() => {
-    if (containerRef.current) {
-      const containerWidth = containerRef.current.offsetWidth;
-
-      const initialScale = containerWidth / 800;
-      setScale(initialScale > 1 ? 1 : initialScale);
-    }
-  }, []);
-
-  useEffect(() => {
-    const calculateScale = () => {
+    const calculateInitialScale = () => {
       if (containerRef.current) {
         const containerWidth = containerRef.current.offsetWidth;
         const initialScale = containerWidth / 800;
         setScale(initialScale > 1 ? 1 : initialScale);
       }
     };
-
-    calculateScale();
-    window.addEventListener("resize", calculateScale);
-    return () => window.removeEventListener("resize", calculateScale);
+    calculateInitialScale();
   }, []);
 
   useEffect(() => {


### PR DESCRIPTION
## 📌 Purpose
After entering full screen, the zoom level was changed and was not consistent 

---

## Corresponding issue: closes #367

---

## 🖼️ Showcase

https://github.com/user-attachments/assets/5a5cdab6-adec-4c1a-b5cb-a502469562d0

---

## 🔧 Changes

- **Consolidated duplicate scale calculation logic**: Removed redundant `useEffect` hooks that were both calculating initial scale
- **Removed window resize listener**: Eliminated the resize event listener that was overriding user's manual zoom adjustments
- **Preserved manual zoom during fullscreen toggle**: Zoom level now remains consistent when entering/exiting fullscreen
---

## ➕ Additional Notes
nah

