### PR TITLE
fix: hide arrow buttons 

### DIFF
--- a/src/components/PapersCarousel.tsx
+++ b/src/components/PapersCarousel.tsx
@@ -63,65 +63,68 @@ function PapersCarousel() {
   const plugins = [Autoplay({ delay: 8000, stopOnInteraction: true })];
 
   return (
-    <div className="mt-3 px-4">
-      <p className="my-8 hidden text-center font-play text-lg font-semibold md:block">
-        Upcoming Exams
-      </p>
+      <div className="mt-3 px-4">
+        <p className="my-8 hidden text-center font-play text-lg font-semibold md:block">
+          Upcoming Exams
+        </p>
 
-      <Carousel
-        opts={{ align: "start", loop: true }}
-        plugins={plugins}
-        className="w-full"
-      >
-        <div className="relative mt-4 flex justify-end gap-4">
-          <CarouselPrevious className="relative" />
-          <CarouselNext className="relative" />
-        </div>
-
-        <CarouselContent>
-          {isLoading ? (
-            <CarouselItem
-              className={`grid ${
-                chunkSize === 2 ? "grid-cols-1 grid-rows-2" : chunkSize === 4 ? "grid-cols-2 grid-rows-2" : "grid-cols-4"
-              } gap-4 lg:auto-rows-fr`}
-            >
-              <SkeletonPaperCard length={chunkSize} />
-            </CarouselItem>
-          ) : (
-            chunkedPapers.map((paperGroup, index) => {
-              const placeholdersNeeded = chunkSize - paperGroup.length;
-
-              return (
-                <CarouselItem
-                  key={`carousel-item-${index}`}
-                  className={`grid ${
-                    chunkSize === 2 ? "grid-cols-1 grid-rows-2" : chunkSize === 4 ? "grid-cols-2 grid-rows-2" : "grid-cols-4"
-                  } gap-4 lg:auto-rows-fr`}
-                >
-                  {paperGroup.map((paper, subIndex) => (
-                    <div key={subIndex} className="h-full">
-                      <UpcomingPaper
-                        subject={paper.subject}
-                        slots={paper.slots}
-                      />
-                    </div>
-                  ))}
-
-                  {Array.from({ length: placeholdersNeeded }).map(
-                    (_, placeholderIndex) => (
-                      <div
-                        key={`placeholder-${placeholderIndex}`}
-                        className="invisible h-full"
-                      ></div>
-                    ),
-                  )}
-                </CarouselItem>
-              );
-            })
+        <Carousel
+            opts={{ align: "start", loop: true }}
+            plugins={plugins}
+            className="w-full"
+        >
+          {/* Only show arrows when there are multiple chunks to scroll through */}
+          {chunkedPapers.length > 1 && displayPapers.length > chunkSize && (
+              <div className="relative mt-4 flex justify-end gap-4">
+                <CarouselPrevious className="relative" />
+                <CarouselNext className="relative" />
+              </div>
           )}
-        </CarouselContent>
-      </Carousel>
-    </div>
+
+          <CarouselContent>
+            {isLoading ? (
+                <CarouselItem
+                    className={`grid ${
+                        chunkSize === 2 ? "grid-cols-1 grid-rows-2" : chunkSize === 4 ? "grid-cols-2 grid-rows-2" : "grid-cols-4"
+                    } gap-4 lg:auto-rows-fr`}
+                >
+                  <SkeletonPaperCard length={chunkSize} />
+                </CarouselItem>
+            ) : (
+                chunkedPapers.map((paperGroup, index) => {
+                  const placeholdersNeeded = chunkSize - paperGroup.length;
+
+                  return (
+                      <CarouselItem
+                          key={`carousel-item-${index}`}
+                          className={`grid ${
+                              chunkSize === 2 ? "grid-cols-1 grid-rows-2" : chunkSize === 4 ? "grid-cols-2 grid-rows-2" : "grid-cols-4"
+                          } gap-4 lg:auto-rows-fr`}
+                      >
+                        {paperGroup.map((paper, subIndex) => (
+                            <div key={subIndex} className="h-full">
+                              <UpcomingPaper
+                                  subject={paper.subject}
+                                  slots={paper.slots}
+                              />
+                            </div>
+                        ))}
+
+                        {Array.from({ length: placeholdersNeeded }).map(
+                            (_, placeholderIndex) => (
+                                <div
+                                    key={`placeholder-${placeholderIndex}`}
+                                    className="invisible h-full"
+                                ></div>
+                            ),
+                        )}
+                      </CarouselItem>
+                  );
+                })
+            )}
+          </CarouselContent>
+        </Carousel>
+      </div>
   );
 }
 


### PR DESCRIPTION
## 📌 Purpose
Fixes the arrow navigation buttons on the home page that were visible but non-functional when there wasn't enough content to scroll through. Previously, the arrows would show up even with only 1-2 subjects, giving users a poor experience with non-working buttons.

---

## Corresponding issue: closes #399 
---

## 🖼️ Showcase
The arrows disappear when no scrolling available
Since the data wasn't seeded , the ss are not available

---

## 🔧 Changes
Modified the conditional rendering logic in PapersCarousel.tsx to only show arrow buttons when there's actually content to scroll through
Added check for displayPapers.length > chunkSize to ensure arrows appear only when necessary
Improved user experience by hiding non-functional UI elements
---

## Additional Notes

The fix maintains responsive behavior across all screen sizes (mobile, tablet, desktop)
No breaking changes to existing functionality
Arrows will automatically show/hide based on content availability
Testing can be done once database connection is properly configured with test data

