### PR TITLE
fix header and upcoming exams disappear and left aligned searchbar

### DIFF
--- a/src/components/PapersCarousel.tsx
+++ b/src/components/PapersCarousel.tsx
@@ -64,7 +64,7 @@ function PapersCarousel() {
 
   return (
       <div className="mt-3 px-4">
-        <p className="my-8 hidden text-center font-play text-lg font-semibold md:block">
+        <p className="my-8 text-center font-play text-lg font-semibold md:block">
           Upcoming Exams
         </p>
 

--- a/src/components/screens/Hero.tsx
+++ b/src/components/screens/Hero.tsx
@@ -6,10 +6,10 @@ import PinnedPapersCarousel from "../PinnedPapersCarousel";
 const Hero = () => {
   return (
     <div id="hero" className="flex flex-col justify-between">
-      <h1 className="mx-auto my-8 hidden text-center font-vipnabd text-3xl font-extrabold md:block">
+      <h1 className="mx-auto my-8 text-center font-vipnabd text-3xl font-extrabold md:block">
         Built by Students for Students
       </h1>
-      <div className="mt-5 px-6">
+      <div className="mt-5 px-[14vw] md:px-6">
         <SearchBar />
       </div>
       <p className="my-8 text-center font-play text-lg font-semibold">


### PR DESCRIPTION
## 📌 Purpose 

Missing of header Heading and upcoming exams in the header sections with left aligned search bar for screens smaller than md.

---

## Corresponding issue: closes #[409]

---

## 🖼️ Showcase

<img width="689" height="597" alt="image" src="https://github.com/user-attachments/assets/cf0436a6-e3db-4cf1-874e-cc76a2ce2119" /> 

                                                                                            Before 

<img width="940" height="1141" alt="image" src="https://github.com/user-attachments/assets/3fe0e433-6a03-4e49-b076-1ea7bf5a5938" />

                                                                                             After

---

## 🔧 Changes
- List the major changes made in this PR.
- Example:
  - Fixed Disappearing of upcoming exams in mobile screen
  - Fixed Disappearing of "built by students for students" in mobile screen
  - Fixed Search bar getting left aligned for  mobile screen


