### PR TITLE
Fixed header issue and light color theme on upload page

### DIFF
--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -375,36 +375,44 @@ export default function Page() {
               multiple={true}
             >
               {({ getRootProps, getInputProps, isDragActive }) => {
-                const pdfUploaded = files.some(f => f.type === "application/pdf");
-                return(
-                <div
-                  className={`relative h-20 w-20 flex-shrink-0 touch-none group${
-            isDragActive || isGlobalDragging
-              ? "border-2 border-solid border-[#6D28D9]"
-              : ""
-          }`}
-                  {...(!pdfUploaded ? getRootProps() : {})}
-                >
-                  {!pdfUploaded && <input {...getInputProps()} />}
-                  <div className={`absolute left-4 top-4 h-16 w-16 rounded-2xl bg-violet-950 ${pdfUploaded ? "text-gray-500 cursor-not-allowed" : "text-white cursor-pointer"}`} />
-                  <div className="absolute left-0 top-0 h-10 w-10 rounded-[20px] bg-violet-950" />
-                  <div className="absolute left-1 top-1 flex h-8 w-8 items-center rounded-[20px] bg-black/50" />
-                  <div className={`absolute left-9 top-9 text-2xl ${pdfUploaded ? "text-gray-500 cursor-not-allowed" : "text-white cursor-pointer"}`}
-                >
-                    <div className={`absolute text-2xl ${pdfUploaded ? "text-gray-500 cursor-not-allowed" : "text-white cursor-pointer"}`}
-                >   
-                    <FiPlus className="h-7 w-7" />
+                const pdfUploaded = files.some(
+                  (f) => f.type === "application/pdf",
+                );
+                return (
+                  <div
+                    className={`relative h-20 w-20 flex-shrink-0 touch-none group${
+                      isDragActive || isGlobalDragging
+                        ? "border-2 border-solid border-[#6D28D9]"
+                        : ""
+                    }`}
+                    {...(!pdfUploaded ? getRootProps() : {})}
+                  >
+                    {!pdfUploaded && <input {...getInputProps()} />}
+                    <div
+                      className={`absolute left-4 top-4 h-16 w-16 rounded-2xl bg-[#A78BFA] dark:bg-violet-950 ${pdfUploaded ? "cursor-not-allowed text-gray-500" : "cursor-pointer text-white"}`}
+                    />
+                    <div className="absolute left-0 top-0 h-10 w-10 rounded-[20px] bg-[#A78BFA] dark:bg-violet-950" />
 
-                    {pdfUploaded && (<div className="absolute left-12 top-1/2 -translate-y-1/2 whitespace-nowrap rounded-md bg-gradient-to-r from-indigo-900 to-violet-900 px-3 py-1 text-xs text-white shadow-lg opacity-0 group-hover:opacity-100 transition-all duration-300 group-hover:translate-x-1">
-                        Only one PDF file is permitted. 
+                    <div className="absolute left-1 top-1 flex h-8 w-8 items-center rounded-[20px] bg-black/30 dark:bg-black/50" />
+                    <div
+                      className={`absolute left-9 top-9 text-2xl ${pdfUploaded ? "cursor-not-allowed text-gray-500" : "cursor-pointer text-white"}`}
+                    >
+                      <div
+                        className={`absolute text-2xl ${pdfUploaded ? "cursor-not-allowed text-gray-500" : "cursor-pointer text-white"}`}
+                      >
+                        <FiPlus className="h-7 w-7" />
+
+                        {pdfUploaded && (
+                          <div className="absolute left-12 top-1/2 -translate-y-1/2 whitespace-nowrap rounded-md bg-gradient-to-r from-indigo-900 to-violet-900 px-3 py-1 text-xs text-white opacity-0 shadow-lg transition-all duration-300 group-hover:translate-x-1 group-hover:opacity-100">
+                            Only one PDF file is permitted.
+                          </div>
+                        )}
+                      </div>
                     </div>
-                    )}
+                    <div className="absolute left-4 top-3 text-xs font-semibold text-white">
+                      {previews.length}
+                    </div>
                   </div>
-                  </div>
-                  <div className="absolute left-4 top-3 text-xs font-semibold text-white">
-                    {previews.length}
-                  </div>
-                </div>
                 );
               }}
             </Dropzone>
@@ -412,7 +420,7 @@ export default function Page() {
           {previews.length > 0 && (
             <section className="mt-6 flex w-full flex-col items-center">
               <div className="flex w-max gap-4">
-                <div className="scrollbar-hide flex w-[80vw] max-w-4xl flex-col justify-between overflow-x-auto overflow-y-hidden rounded-[40px] border-[6px] border-indigo-900 bg-indigo-900/10 p-4 sm:p-6 md:w-max md:p-8">
+                <div className="scrollbar-hide flex w-[80vw] max-w-4xl flex-col justify-between overflow-x-auto overflow-y-hidden rounded-[40px] border-[6px] border-[#A78BFA] bg-indigo-900/10 p-4 dark:border-indigo-900 sm:p-6 md:w-max md:p-8">
                   <DndContext
                     sensors={sensors}
                     collisionDetection={closestCenter}
@@ -493,7 +501,7 @@ export default function Page() {
           <Button
             onClick={handleUpload}
             disabled={isUploading || files.length === 0}
-            className="mt-8 rounded-[40px] bg-violet-950 px-8 py-3 text-xl text-white hover:bg-violet-800"
+            className="mt-8 rounded-[40px] bg-[#A78BFA] px-8 py-3 text-xl text-white hover:bg-[#8B5CF6] dark:bg-violet-950 dark:hover:bg-violet-800"
           >
             {isUploading ? "Uploading..." : "Upload"}
           </Button>

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -108,20 +108,25 @@ function Navbar() {
                 </DropdownMenuTrigger>
 
                 <DropdownMenuContent
-                  className="w-56 rounded-2xl border border-[#3A3745] border-[rgba(255,255,255,0.1)] bg-[#e8e9ff] text-gray-700 shadow-2xl backdrop-blur-sm hover:bg-slate-50 dark:bg-black dark:text-white dark:hover:bg-[#1A1823]"
+                  className="mt-2 w-56 space-y-1 rounded-3xl border border-[#3A3745] bg-[#e8e9ff] py-2 text-gray-700 shadow-lg backdrop-blur-sm dark:border-[#3A3745] dark:bg-black dark:text-white"
                   align="start"
                 >
                   <DropdownMenuItem
                     asChild
                     onSelect={(e) => e.preventDefault()}
                   >
-                    <PinnedModal />
+                    <div className="flex w-full items-center gap-3 rounded-lg px-3 py-1 transition hover:bg-[#1A1823] hover:text-white">
+                      <PinnedModal />
+                    </div>
                   </DropdownMenuItem>
+
                   <DropdownMenuItem
                     asChild
                     onSelect={(e) => e.preventDefault()}
                   >
-                    <RequestModal />
+                    <div className="flex w-full items-center gap-3 rounded-lg px-3 py-1 transition hover:bg-[#1A1823] hover:text-white">
+                      <RequestModal />
+                    </div>
                   </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>


### PR DESCRIPTION
## 📌 Purpose
The header on the catalogue page had the pinned subjects and requested papers buttons conjoined; they worked separately, but in the UI were like one button.
And the upload page UI did not match the colour scheme in light mode
This PR resolved these issues

## Corresponding issue: closes #396 #398 

## 🖼️ Showcase
<img width="862" height="570" alt="image" src="https://github.com/user-attachments/assets/5b9fcc73-6004-4d5b-a89c-3e880a36c3ba" />
<img width="418" height="263" alt="image" src="https://github.com/user-attachments/assets/0f3b65f1-3dcf-4954-8348-c9eb894cd57c" />

## 🔧 Changes
-  I just reused the architecture in the floating navbar component that we use in mobile for the navbar, which was very similar to this, with just a few differences.
- And the colour theme issue was resolved.
