### PR TITLE
Fixed responsiveness and No upcoming papers text

### DIFF
--- a/src/components/CatalogueContent.tsx
+++ b/src/components/CatalogueContent.tsx
@@ -316,16 +316,21 @@ const CatalogueContentInner = ({ subject }: { subject: string | null }) => {
           </div>
 
           {/* Select/Deselect/Download All Buttons */}
-          <div className="mb-8 flex w-full items-center justify-end gap-4">
+          <div className="mb-6 mt-5 flex w-full flex-wrap items-center justify-start gap-3 sm:gap-4 md:mt-4 md:justify-end">
             <SortComponent
               onSortChange={setSortOption}
               currentSort={sortOption}
             />
-            <SidebarButton onClick={handleSelectAll}>Select All</SidebarButton>
-            <SidebarButton onClick={handleDeselectAll}>
+
+            <SidebarButton onClick={handleSelectAll} className="order-2">
+              Select All
+            </SidebarButton>
+
+            <SidebarButton onClick={handleDeselectAll} className="order-2">
               Deselect All
             </SidebarButton>
-            <SidebarButton onClick={handleDownloadSelected}>
+
+            <SidebarButton onClick={handleDownloadSelected} className="order-2">
               Download Selected
             </SidebarButton>
           </div>

--- a/src/components/PapersCarousel.tsx
+++ b/src/components/PapersCarousel.tsx
@@ -23,10 +23,9 @@ function PapersCarousel() {
 
   useEffect(() => {
     const handleResize = () => {
-      if(window.innerWidth <= 540){
+      if (window.innerWidth <= 540) {
         setChunkSize(2);
-      }
-      else if (window.innerWidth <= 920) {
+      } else if (window.innerWidth <= 920) {
         setChunkSize(4);
       } else {
         setChunkSize(8);
@@ -42,7 +41,9 @@ function PapersCarousel() {
     const fetchPapers = async () => {
       try {
         setIsLoading(true);
-        const response = await axios.get<IUpcomingPaper[]>("/api/upcoming-papers");
+        const response = await axios.get<IUpcomingPaper[]>(
+          "/api/upcoming-papers",
+        );
         setDisplayPapers(response.data);
       } catch (error) {
         console.error("Failed to fetch papers:", error);
@@ -62,69 +63,89 @@ function PapersCarousel() {
   const chunkedPapers = chunkArray(displayPapers, chunkSize);
   const plugins = [Autoplay({ delay: 8000, stopOnInteraction: true })];
 
-  return (
+  if (chunkedPapers.length === 0)
+    return (
       <div className="mt-3 px-4">
         <p className="my-8 text-center font-play text-lg font-semibold md:block">
           Upcoming Exams
         </p>
-
-        <Carousel
-            opts={{ align: "start", loop: true }}
-            plugins={plugins}
-            className="w-full"
-        >
-          {/* Only show arrows when there are multiple chunks to scroll through */}
-          {chunkedPapers.length > 1 && displayPapers.length > chunkSize && (
-              <div className="relative mt-4 flex justify-end gap-4">
-                <CarouselPrevious className="relative" />
-                <CarouselNext className="relative" />
-              </div>
-          )}
-
-          <CarouselContent>
-            {isLoading ? (
-                <CarouselItem
-                    className={`grid ${
-                        chunkSize === 2 ? "grid-cols-1 grid-rows-2" : chunkSize === 4 ? "grid-cols-2 grid-rows-2" : "grid-cols-4"
-                    } gap-4 lg:auto-rows-fr`}
-                >
-                  <SkeletonPaperCard length={chunkSize} />
-                </CarouselItem>
-            ) : (
-                chunkedPapers.map((paperGroup, index) => {
-                  const placeholdersNeeded = chunkSize - paperGroup.length;
-
-                  return (
-                      <CarouselItem
-                          key={`carousel-item-${index}`}
-                          className={`grid ${
-                              chunkSize === 2 ? "grid-cols-1 grid-rows-2" : chunkSize === 4 ? "grid-cols-2 grid-rows-2" : "grid-cols-4"
-                          } gap-4 lg:auto-rows-fr`}
-                      >
-                        {paperGroup.map((paper, subIndex) => (
-                            <div key={subIndex} className="h-full">
-                              <UpcomingPaper
-                                  subject={paper.subject}
-                                  slots={paper.slots}
-                              />
-                            </div>
-                        ))}
-
-                        {Array.from({ length: placeholdersNeeded }).map(
-                            (_, placeholderIndex) => (
-                                <div
-                                    key={`placeholder-${placeholderIndex}`}
-                                    className="invisible h-full"
-                                ></div>
-                            ),
-                        )}
-                      </CarouselItem>
-                  );
-                })
-            )}
-          </CarouselContent>
-        </Carousel>
+        <p className="my-8 text-center font-play text-lg font-semibold md:block">
+          <i>No more upcoming papers, Enjoy your break!</i>
+        </p>
       </div>
+    );
+
+  return (
+    <div className="mt-3 px-4">
+      <p className="my-8 text-center font-play text-lg font-semibold md:block">
+        Upcoming Exams
+      </p>
+
+      <Carousel
+        opts={{ align: "start", loop: true }}
+        plugins={plugins}
+        className="w-full"
+      >
+        {/* Only show arrows when there are multiple chunks to scroll through */}
+        {chunkedPapers.length > 1 && displayPapers.length > chunkSize && (
+          <div className="relative mt-4 flex justify-end gap-4">
+            <CarouselPrevious className="relative" />
+            <CarouselNext className="relative" />
+          </div>
+        )}
+
+        <CarouselContent>
+          {isLoading ? (
+            <CarouselItem
+              className={`grid ${
+                chunkSize === 2
+                  ? "grid-cols-1 grid-rows-2"
+                  : chunkSize === 4
+                    ? "grid-cols-2 grid-rows-2"
+                    : "grid-cols-4"
+              } gap-4 lg:auto-rows-fr`}
+            >
+              <SkeletonPaperCard length={chunkSize} />
+            </CarouselItem>
+          ) : (
+            chunkedPapers.map((paperGroup, index) => {
+              const placeholdersNeeded = chunkSize - paperGroup.length;
+
+              return (
+                <CarouselItem
+                  key={`carousel-item-${index}`}
+                  className={`grid ${
+                    chunkSize === 2
+                      ? "grid-cols-1 grid-rows-2"
+                      : chunkSize === 4
+                        ? "grid-cols-2 grid-rows-2"
+                        : "grid-cols-4"
+                  } gap-4 lg:auto-rows-fr`}
+                >
+                  {paperGroup.map((paper, subIndex) => (
+                    <div key={subIndex} className="h-full">
+                      <UpcomingPaper
+                        subject={paper.subject}
+                        slots={paper.slots}
+                      />
+                    </div>
+                  ))}
+
+                  {Array.from({ length: placeholdersNeeded }).map(
+                    (_, placeholderIndex) => (
+                      <div
+                        key={`placeholder-${placeholderIndex}`}
+                        className="invisible h-full"
+                      ></div>
+                    ),
+                  )}
+                </CarouselItem>
+              );
+            })
+          )}
+        </CarouselContent>
+      </Carousel>
+    </div>
   );
 }
 

--- a/src/components/pdfViewer.tsx
+++ b/src/components/pdfViewer.tsx
@@ -200,7 +200,75 @@ export default function PdfViewer({ url, name }: PdfViewerProps) {
   }, []);
 
   return (
-    <div className="flex w-full justify-center gap-6 p-3 md:p-0">
+    <div className="w-full flex-row justify-center gap-6 p-3 md:flex md:p-0">
+      {!isFullscreen && (
+        <div className="mx-auto mb-6 mt-2 flex w-full max-w-[480px] flex-col items-center gap-3 rounded-xl bg-[#F3F5FF] p-3 shadow dark:bg-[#262635] sm:flex-row md:hidden">
+          <div className="flex items-center gap-2">
+            <Button
+              onClick={goToPreviousPage}
+              disabled={pageNumber <= 1}
+              className="h-9 w-9 rounded p-0 text-white transition hover:bg-[#6536c1] disabled:bg-[#706b7a] disabled:opacity-50"
+            >
+              <FaLessThan />
+            </Button>
+
+            <input
+              type="text"
+              value={inputValue}
+              onChange={(e) => setInputValue(e.target.value)}
+              onKeyDown={(e) => handlePageChange(e)}
+              onFocus={() => setInputValue("")}
+              className="h-9 w-14 rounded border bg-[#e7e9ff] p-1 text-center text-sm [appearance:textfield] dark:bg-[#1f1f2a] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+            />
+
+            <span className="text-sm font-medium">of {numPages ?? 1}</span>
+
+            <Button
+              onClick={goToNextPage}
+              disabled={pageNumber >= (numPages ?? 1)}
+              className="h-9 w-9 rounded p-0 text-white transition hover:bg-[#6536c1] disabled:bg-[#706b7a] disabled:opacity-50"
+            >
+              <FaGreaterThan />
+            </Button>
+          </div>
+
+          <div className="flex items-center gap-2">
+            <Button
+              onClick={zoomOut}
+              disabled={scale <= 0.25}
+              className="h-9 w-9 rounded p-0 text-white transition hover:bg-[#6536c1] disabled:bg-gray-300"
+            >
+              <ZoomOut />
+            </Button>
+
+            <span className="w-10 text-center text-sm font-medium">
+              {(scale * 100).toFixed(0)}%
+            </span>
+
+            <Button
+              onClick={zoomIn}
+              disabled={scale >= 3}
+              className="h-9 w-9 rounded p-0 text-white transition hover:bg-[#6536c1] disabled:bg-gray-300"
+            >
+              <ZoomIn />
+            </Button>
+
+            <ShareButton />
+
+            <Button onClick={downloadPDF} className="h-9 w-9 rounded p-0">
+              <Download />
+            </Button>
+
+            <Button
+              onClick={toggleFullscreen}
+              className="h-9 w-9 rounded p-0 text-white transition hover:bg-[#6536c1]"
+            >
+              {isFullscreen ? <Minimize2 /> : <Maximize2 />}
+            </Button>
+          </div>
+        </div>
+      )}
+
       <div
         ref={containerRef}
         className="max-h-[70vh] overflow-auto rounded-lg bg-[#F3F5FF] px-4 shadow-lg dark:bg-[#070114]"
@@ -242,6 +310,7 @@ export default function PdfViewer({ url, name }: PdfViewerProps) {
               </div>
             ))}
         </Document>
+
         {isFullscreen && (
           <div className="fixed bottom-4 left-1/2 z-50 mt-4 flex -translate-x-1/2 flex-col items-center gap-4 rounded-lg bg-[#F3F5FF] p-4 shadow dark:bg-[#262635] sm:flex-row">
             <div className="flex items-center gap-2">
@@ -305,7 +374,7 @@ export default function PdfViewer({ url, name }: PdfViewerProps) {
       </div>
 
       {!isFullscreen && (
-        <div className="flex h-fit flex-col items-center gap-4 rounded-lg bg-[#F3F5FF] p-4 shadow dark:bg-[#262635]">
+        <div className="hidden h-fit flex-col items-center gap-4 rounded-lg bg-[#F3F5FF] p-4 shadow dark:bg-[#262635] md:flex">
           <div className="flex flex-col items-center gap-3">
             <Button
               onClick={toggleFullscreen}


### PR DESCRIPTION
## 📌 Purpose
If there's no upcoming paper the section was just blank, default text needed here.
The PDF viewer control bar on the side looked very weird on mobile so it needs to be changed and optimised for mobile.
And there are a few other responsiveness issues regarding catalogue page buttons

## Corresponding issue: closes #403 

## 🖼️ Showcase
<img width="698" height="289" alt="image" src="https://github.com/user-attachments/assets/fa1e0f99-c076-4071-aecb-28585a8bd54b" />
<img width="381" height="431" alt="image" src="https://github.com/user-attachments/assets/6b87956a-6280-4226-b82d-8e767c6b6625" />
<img width="423" height="580" alt="image" src="https://github.com/user-attachments/assets/5f343d59-37ef-4c20-b262-7030d90f148e" />

## 🔧 Changes
- Added text in the upcoming papers section if there wasn't any papers to show
- Moved control bar to the top in mobile for ease of use and no weird UI experience and fixed other responsiveness issues as well. 
