### PR TITLE
fix: confusing message display when upload size was greater than the …

### DIFF
--- a/src/app/upload/page.tsx
+++ b/src/app/upload/page.tsx
@@ -136,6 +136,15 @@ export default function Page() {
         return;
       }
 
+      const totalSize = allFiles.reduce(
+        (sum, f) => sum + f.size,
+        0,
+      );
+      if (totalSize > maxFileSize){
+        toast.error("The total upload size exceeds 5MB.", { id: toastId });
+        return;
+      }
+
       const invalidFiles = acceptedFiles.filter(
         (file) =>
           file.size > maxFileSize || !allowedFileTypes.includes(file.type),
@@ -143,7 +152,7 @@ export default function Page() {
 
       if (invalidFiles.length > 0) {
         toast.error(
-          "Some files are invalid. Make sure each is under 5MB and of allowed types (PDF, JPEG, PNG, GIF).",
+          "Some files are invalid. Make sure the total size is below 5MB and files are of allowed types (PDF, JPEG, PNG, GIF).",
           { id: toastId },
         );
         return;


### PR DESCRIPTION
…limit.

## 📌 Purpose
- Fixes the issue where uploading files larger than the 5MB limit showed a confusing 'Failed to upload papers' message instead of the specific error.
- And a missing error display toast for the same.

## Corresponding issue: none just found it randomly


## 🔧 Changes
- Fixed the error message for upload size
- Made error message for invalid files more appropriate

