### PR TITLE
Gslmao/seperate logic

### DIFF
--- a/src/app/api/course-list/route.ts
+++ b/src/app/api/course-list/route.ts
@@ -1,14 +1,11 @@
 import { NextResponse } from "next/server";
-import { connectToDatabase } from "@/lib/database/mongoose";
-import { Course } from "@/db/course";
+import { getCourseList } from "@/lib/services/subject";
 
 export const dynamic = "force-dynamic";
 
 export async function GET() {
   try {
-    await connectToDatabase();
-    const courses = await Course.find().lean();
-
+    const courses = await getCourseList();
     return NextResponse.json(courses, { status: 200 });
   } catch (error) {
     console.error(error);

--- a/src/app/api/paper-by-id/[id]/route.ts
+++ b/src/app/api/paper-by-id/[id]/route.ts
@@ -1,23 +1,16 @@
 import { NextResponse } from "next/server";
-import { connectToDatabase } from "@/lib/database/mongoose";
-import Paper from "@/db/papers";
 import { Types } from "mongoose";
+import { getPaperById } from "@/lib/services/paper";
 
 export async function GET(req: Request, { params }: { params: { id: string } }) {
   try {
-    await connectToDatabase();
-
     const { id } = params;
-
+    
     if (!Types.ObjectId.isValid(id)) {
       return NextResponse.json({ message: "Invalid paper ID" }, { status: 400 });
     }
 
-    const paper = await Paper.findById(id);
-
-    if (!paper) {
-      return NextResponse.json({ message: "Paper not found" }, { status: 404 });
-    }
+    const paper = await getPaperById(id);
 
     return NextResponse.json(paper, { status: 200 });
   } catch (error) {

--- a/src/app/api/papers/count/route.ts
+++ b/src/app/api/papers/count/route.ts
@@ -1,21 +1,13 @@
 import { NextResponse } from "next/server";
-import { connectToDatabase } from "@/lib/database/mongoose";
-import CourseCount from "@/db/course";
+import { getCourseCounts } from "@/lib/services/paper";
 
 export const dynamic = "force-dynamic";
 
 export async function GET(req: Request) {
   try {
-    await connectToDatabase();
+    const courseCount = await getCourseCounts();
 
-    const count = await CourseCount.find().lean();
-
-    const formatted = count.map((item) => ({
-      name: item.name,
-      count: item.count,
-    }));
-
-    return NextResponse.json(formatted, { status: 200 });
+    return NextResponse.json(courseCount, { status: 200 });
   } catch (error) {
     return NextResponse.json(
       { message: "Failed to fetch course counts", error },

--- a/src/app/api/report-tag/route.ts
+++ b/src/app/api/report-tag/route.ts
@@ -1,48 +1,10 @@
 import { NextResponse } from "next/server";
-import { connectToDatabase } from "@/lib/database/mongoose";
-import TagReport from "@/db/tagReport";
-import { Ratelimit } from "@upstash/ratelimit";
-import { redis } from "@/lib/utils/redis";
-
-const exams: string[] = ["CAT-1", "CAT-2", "FAT", "Model CAT-1", "Model CAT-2", "Model FAT"]
-
-interface ReportedFieldInput {
-  field: string;
-  value?: string;
-}
-interface ReportTagBody {
-  paperId?: string;
-  reportedFields?: unknown;
-  comment?: unknown;
-  reporterEmail?: unknown;
-  reporterId?: unknown;
-}
-
-const ALLOWED_FIELDS = ["subject", "courseCode", "exam", "slot", "year"];
-
-function getRateLimit(){
-  return new Ratelimit({
-    redis,
-    limiter: Ratelimit.slidingWindow(3, "1 h"),//per id - 3 request - per hour
-    analytics: true,
-});
-}
-function getClientIp(req: Request & { ip?: string}): string {
-  const xff = req.headers.get("x-forwarded-for");
-  if (typeof xff === "string" && xff.length > 0) {
-    return xff.split(",")[0]?.trim()??"";
-  }
-  const xri = req.headers.get("x-real-ip");
-  if (typeof xri === "string" && xri.length > 0) {
-    return xri;
-  }
-  return "0.0.0.0";
-}
+import { reportTag, ReportTagBody } from "@/lib/services/report";
+import { rateLimitCheck } from "@/lib/utils/rate-limiter";
+import { customErrorHandler } from "@/lib/utils/error";
 
 export async function POST(req: Request & { ip?: string }) {
   try {
-    await connectToDatabase();
-    const ratelimit = getRateLimit();
     const body = (await req.json()) as ReportTagBody;
     const paperId = typeof body.paperId === "string" ? body.paperId : undefined;
 
@@ -52,61 +14,8 @@ export async function POST(req: Request & { ip?: string }) {
         { status: 400 }
       );
     }
-    const ip = getClientIp(req);
-    const key = `${ip}::${paperId}`;
-    const { success } = await ratelimit.limit(key);
-
-    if (!success) {
-      return NextResponse.json(
-        { error: "Rate limit exceeded for reporting." },
-        { status: 429 }
-      );
-    }
-    const MAX_REPORTS_PER_PAPER = 5; 
-    const count = await TagReport.countDocuments({ paperId });
-
-    if (count >= MAX_REPORTS_PER_PAPER) {
-      return NextResponse.json(
-        { error: "Received many reports; we are currently working on it." },
-        { status: 429 }
-      );
-    }
-      const reportedFields: ReportedFieldInput[] = Array.isArray(body.reportedFields)
-        ? body.reportedFields
-            .map((r): ReportedFieldInput | null => {
-               if (!r || typeof r !== "object") return null;
-
-              const field = typeof (r as { field?: unknown }).field === "string" ? (r as { field: string }).field.trim() : "";
-              const value = typeof (r as { value?: unknown }).value === "string" ? (r as { value: string }).value.trim() : undefined;
-             return field ? { field, value } : null;
-            })
-             .filter((r): r is ReportedFieldInput => r !== null):[];
-
-    for (const rf of reportedFields) {
-      if (!ALLOWED_FIELDS.includes(rf.field)) {
-        return NextResponse.json(
-          { error: `Invalid field: ${rf.field}` },
-          { status: 400 }
-        );
-      }
-      if (rf.field === "exam" && rf.value) {
-        if (!exams.some(e => e.toLowerCase() === rf.value?.toLowerCase())) {
-          return NextResponse.json(
-            { error: `Invalid exam value: ${rf.value}` },
-            { status: 400 }
-          );
-        }
-      }
-    }
-
-    const newReport = await TagReport.create({
-      paperId,
-      reportedFields,
-      comment: typeof body.comment === "string" ? body.comment : undefined,
-      reporterEmail: typeof body.reporterEmail === "string" ? body.reporterEmail : undefined,
-      reporterId: typeof body.reporterId === "string" ? body.reporterId : undefined,
-
-    });
+    await rateLimitCheck(req, paperId);
+    const newReport = await reportTag(paperId, body);
 
     return NextResponse.json(
       { message: "Report submitted.", report: newReport },
@@ -114,9 +23,6 @@ export async function POST(req: Request & { ip?: string }) {
     );
   } catch (err) {
     console.error(err);
-    return NextResponse.json(
-      { error: "Failed to submit tag report." },
-      { status: 500 }
-    );
+    return customErrorHandler(err, "Failed to submit tag report.");
   }
 }

--- a/src/components/ReportTagModal.tsx
+++ b/src/components/ReportTagModal.tsx
@@ -228,7 +228,7 @@ if (reportedFields.length === 0 && comment.trim().length === 0) {
       error: (err: unknown)=>{
           if (axios.isAxiosError<ReportResponse>(err)) {
             return ( 
-              err.response?.data?.error ??
+              err.response?.data?.message ??
               err.message ??
               "Failed to submit report."
             );

--- a/src/lib/services/paper.ts
+++ b/src/lib/services/paper.ts
@@ -3,24 +3,48 @@ import { type IPaper } from "@/interface";
 import { escapeRegExp } from "@/lib/utils/regex";
 import { extractUniqueValues } from "@/lib/utils/paper-aggregation";
 import { connectToDatabase } from "../database/mongoose";
+import CourseCount from "@/db/course";
 
 export async function getPapersBySubject(subject: string) {
-    if (!subject){
-        throw new Error("Subject query parameter is required");
-    }
+	if (!subject){
+		throw new Error("Subject query parameter is required");
+	}
+	await connectToDatabase();
+	
+	const escapedSubject = escapeRegExp(subject);
+	const papers: IPaper[] = await Paper.find({
+		subject: { $regex: new RegExp(`${escapedSubject}`, "i") },
+	});
 
-    await connectToDatabase();
-    
-    const escapedSubject = escapeRegExp(subject);
-    const papers: IPaper[] = await Paper.find({
-        subject: { $regex: new RegExp(`${escapedSubject}`, "i") },
-    });
+	const uniqueValues = extractUniqueValues(papers);
 
-    const uniqueValues = extractUniqueValues(papers);
+	return {
+		papers,
+		...uniqueValues,
+	}
 
-    return {
-        papers,
-        ...uniqueValues,
-    }
+}
 
+export async function getPaperById(id: string) {
+	await connectToDatabase();
+	const paper = await Paper.findById(id);
+
+	if (!paper) {
+		throw new Error("Paper not found"); // 404
+	}
+
+	return paper;
+}
+
+export async function getCourseCounts(){
+	await connectToDatabase();
+
+	const count = await CourseCount.find().lean();
+
+	const formatted = count.map((item) => ({
+		name: item.name,
+		count: item.count,
+	}));
+
+	return formatted;
 }

--- a/src/lib/services/report.ts
+++ b/src/lib/services/report.ts
@@ -1,0 +1,62 @@
+import { connectToDatabase } from "@/lib/database/mongoose";
+import TagReport from "@/db/tagReport";
+import { CustomError } from "@/lib/utils/error";
+
+const exams: string[] = ["CAT-1", "CAT-2", "FAT", "Model CAT-1", "Model CAT-2", "Model FAT"]
+const ALLOWED_FIELDS = ["subject", "courseCode", "exam", "slot", "year"];
+const MAX_REPORTS_PER_PAPER = 5; 
+
+export interface ReportTagBody {
+  paperId?: string;
+  reportedFields?: unknown;
+  comment?: unknown;
+  reporterEmail?: unknown;
+  reporterId?: unknown;
+}
+
+interface ReportedFieldInput {
+  field: string;
+  value?: string;
+}
+
+export async function reportTag(paperId: string, body: ReportTagBody) {
+  await connectToDatabase();
+  const MAX_REPORTS_PER_PAPER = 5; 
+  const count = await TagReport.countDocuments({ paperId });
+
+  if (count >= MAX_REPORTS_PER_PAPER) {
+    throw new CustomError("Received many reports; we are currently working on it.", 429)
+  }
+    const reportedFields: ReportedFieldInput[] = Array.isArray(body.reportedFields)
+      ? body.reportedFields
+        .map((r): ReportedFieldInput | null => {
+          if (!r || typeof r !== "object") return null;
+
+          const field = typeof (r as { field?: unknown }).field === "string" ? (r as { field: string }).field.trim() : "";
+          const value = typeof (r as { value?: unknown }).value === "string" ? (r as { value: string }).value.trim() : undefined;
+          return field ? { field, value } : null;
+        })
+          .filter((r): r is ReportedFieldInput => r !== null):[];
+
+  for (const rf of reportedFields) {
+    if (!ALLOWED_FIELDS.includes(rf.field)) {
+      throw new CustomError(`Invalid field: ${rf.field}`, 400);
+    }
+    
+    if (rf.field === "exam" && rf.value) {
+      if (!exams.some(e => e.toLowerCase() === rf.value?.toLowerCase())) {
+        throw new CustomError(`Invalid exam value: ${rf.value}`, 400);
+      }
+    }
+  }
+
+  const newReport = await TagReport.create({
+    paperId,
+    reportedFields,
+    comment: typeof body.comment === "string" ? body.comment : undefined,
+    reporterEmail: typeof body.reporterEmail === "string" ? body.reporterEmail : undefined,
+    reporterId: typeof body.reporterId === "string" ? body.reporterId : undefined,
+
+  });
+  return newReport;
+}

--- a/src/lib/services/subject.ts
+++ b/src/lib/services/subject.ts
@@ -7,7 +7,7 @@ import RelatedSubject from "@/db/relatedSubjects";
 export async function getCourseList(){
 	await connectToDatabase();
 	return await Course.find().lean();
-
+}
 export async function getRelatedSubjects(subject: string) {
 	await connectToDatabase();
 	const escapedSubject = escapeRegExp(subject);

--- a/src/lib/services/subject.ts
+++ b/src/lib/services/subject.ts
@@ -1,0 +1,7 @@
+import { connectToDatabase } from "@/lib/database/mongoose";
+import { Course } from "@/db/course";
+
+export async function getCourseList(){
+	await connectToDatabase();
+	return await Course.find().lean();
+}

--- a/src/lib/utils/error.ts
+++ b/src/lib/utils/error.ts
@@ -1,0 +1,25 @@
+import { NextResponse } from "next/server";
+
+export class CustomError extends Error {
+    status: number;
+    
+    constructor(message: string, status: number) {
+        super(message);
+        this.status = status;
+        Object.setPrototypeOf(this, CustomError.prototype);
+    }
+}
+
+export function customErrorHandler(error: unknown, defaultMessage: string) {
+    if (error instanceof CustomError) {
+        return NextResponse.json(
+            {message: error.message},
+            {status: error.status}
+        );
+    } else {
+        return NextResponse.json(
+            {message: defaultMessage},
+            {status: 500}
+        );
+    }
+}

--- a/src/lib/utils/rate-limiter.ts
+++ b/src/lib/utils/rate-limiter.ts
@@ -1,0 +1,31 @@
+import { redis } from "@/lib/utils/redis";
+import { Ratelimit } from "@upstash/ratelimit";
+import { CustomError } from "./error";
+
+function getClientIp(req: Request & { ip?: string}): string {
+  const xff = req.headers.get("x-forwarded-for");
+  if (typeof xff === "string" && xff.length > 0) {
+    return xff.split(",")[0]?.trim()??"";
+  }
+  const xri = req.headers.get("x-real-ip");
+  if (typeof xri === "string" && xri.length > 0) {
+    return xri;
+  }
+  return "0.0.0.0";
+}
+
+export async function rateLimitCheck(req: Request & { ip?: string }, paperId: string) {
+  const ratelimit = new Ratelimit({
+    redis,
+    limiter: Ratelimit.slidingWindow(3, "1 h"),//per id - 3 request - per hour
+    analytics: true,
+  });
+
+  const ip = getClientIp(req);
+  const key = `${ip}::${paperId}`;
+  const { success } = await ratelimit.limit(key);
+
+  if (!success) {
+    throw new CustomError("Rate limit exceeded for reporting.", 429);
+  }
+}


### PR DESCRIPTION
## 📌 Purpose
This PR refactors 4 API Endpoints 
  course-list/
  paper-by-id/
  paper/count
  report-tag/

## 🔧 Changes
- Refactored the endpoints listed above
- Implemented CustomError class and customErrorHandler to catch errors in the service logic (used only in report-tag/ for now)
- Indentation and Black line queries were fixed to address the issues in PR#438 -  https://github.com/CodeChefVIT/papers-codechef/pull/438

## ➕ Additional Notes
"@/components/ReportTagModal' line 231
The error message always fell back to "err.message" instead of "err.response.data.error", since the error handler which was implemented sent back the error message as "err.response.data.message", instead of "err.response.data.error", so that was tweaked to comply with the backend.