### PR TITLE
feat: rate-limiting endpoints and migration to Upstash

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -23,10 +23,10 @@ GOOGLE_CLOUD_BUCKET=""                      # Your Google Cloud Storage Bucket n
 GOOGLE_APPLICATION_CREDENTIALS_JSON=""      # The content of the JSON file you download when creating a service account key
 
 # Vercel KV
-KV_URL=""                           # The URL of your Vercel KV instance
-KV_REST_API_URL=""                  # The REST API URL of your Vercel KV instance
-KV_REST_API_TOKEN=""                # The REST API token for your Vercel KV instance
-KV_REST_API_READ_ONLY_TOKEN=""      # The read-only REST API token for your Vercel KV instance
+# KV_URL=""                           # The URL of your Vercel KV instance
+# KV_REST_API_URL=""                  # The REST API URL of your Vercel KV instance
+# KV_REST_API_TOKEN=""                # The REST API token for your Vercel KV instance
+# KV_REST_API_READ_ONLY_TOKEN=""      # The read-only REST API token for your Vercel KV instance
 
 # Upstash_Redis
 UPSTASH_REDIS_REST_URL=""           # REST URL of your Upstash Redis database

--- a/next.config.js
+++ b/next.config.js
@@ -8,7 +8,12 @@ await import("./src/env.js");
 const config = {
   swcMinify: false,
   images: {
-    domains: ["storage.googleapis.com"],
+    remotePatterns: [
+      {
+        protocol: "https",
+        hostname: "storage.googleapis.com",
+      },
+    ],
   },
   async headers() {
     return [

--- a/package.json
+++ b/package.json
@@ -31,7 +31,6 @@
     "@ungap/with-resolvers": "^0.1.0",
     "@upstash/ratelimit": "^2.0.5",
     "@upstash/redis": "^1.33.0",
-    "@vercel/kv": "^3.0.0",
     "axios": "^1.8.4",
     "canvas": "^3.2.0",
     "class-variance-authority": "^0.7.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -71,9 +71,6 @@ importers:
       '@upstash/redis':
         specifier: ^1.33.0
         version: 1.33.0
-      '@vercel/kv':
-        specifier: ^3.0.0
-        version: 3.0.0
       axios:
         specifier: ^1.8.4
         version: 1.12.2
@@ -1257,10 +1254,6 @@ packages:
 
   '@upstash/redis@1.35.7':
     resolution: {integrity: sha512-bdCdKhke+kYUjcLLuGWSeQw7OLuWIx3eyKksyToLBAlGIMX9qiII0ptp8E0y7VFE1yuBxBd/3kSzJ8774Q4g+A==}
-
-  '@vercel/kv@3.0.0':
-    resolution: {integrity: sha512-pKT8fRnfyYk2MgvyB6fn6ipJPCdfZwiKDdw7vB+HL50rjboEBHDVBEcnwfkEpVSp2AjNtoaOUH7zG+bVC/rvSg==}
-    engines: {node: '>=14.6'}
 
   '@webassemblyjs/ast@1.14.1':
     resolution: {integrity: sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==}
@@ -4815,10 +4808,6 @@ snapshots:
   '@upstash/redis@1.35.7':
     dependencies:
       uncrypto: 0.1.3
-
-  '@vercel/kv@3.0.0':
-    dependencies:
-      '@upstash/redis': 1.35.7
 
   '@webassemblyjs/ast@1.14.1':
     dependencies:

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -1,6 +1,5 @@
 "use client";
 
-import { useEffect, useState } from "react";
 import { type IPaper } from "@/interface";
 import Image from "next/image";
 import { Eye, Download, Check } from "lucide-react";
@@ -24,22 +23,12 @@ interface CardProps {
 }
 
 const Card = ({ paper, onSelect, isSelected }: CardProps) => {
-  const [checked, setChecked] = useState<boolean>(isSelected);
-
-  useEffect(() => {
-    setChecked(isSelected);
-  }, [isSelected]);
-
   const handleDownload = async (paper: IPaper) => {
     await downloadFile(getSecureUrl(paper.file_url), generateFileName(paper));
   };
 
   const handleCheckboxChange = () => {
-    setChecked((prev) => {
-      const newChecked = !prev;
-      onSelect(paper, newChecked);
-      return newChecked;
-    });
+    onSelect(paper, !isSelected);
   };
 
   const paperLink = `/paper/${paper._id}`;
@@ -48,7 +37,7 @@ const Card = ({ paper, onSelect, isSelected }: CardProps) => {
     <div
       className={cn(
         "overflow-hidden rounded-sm border-2 border-[#734DFF] bg-[#FFFFFF] font-play transition-all duration-150 hover:bg-[#EFEAFF] dark:border-[#36266D] dark:bg-[#171720] hover:dark:bg-[#262635]",
-        checked && "bg-white",
+        isSelected && "bg-white",
       )}
     >
       <Link href={paperLink} target="_blank" rel="noopener noreferrer">
@@ -100,7 +89,7 @@ const Card = ({ paper, onSelect, isSelected }: CardProps) => {
       <div className="flex items-center justify-between gap-2 px-4 pb-4 font-play">
         <div className="flex items-center gap-2">
           <input
-            checked={checked}
+            checked={isSelected}
             onChange={handleCheckboxChange}
             className="h-5 w-5 accent-[#7480FF]"
             type="checkbox"

--- a/src/lib/utils/ratelimit.ts
+++ b/src/lib/utils/ratelimit.ts
@@ -1,20 +1,20 @@
 import { Ratelimit } from "@upstash/ratelimit";
-import { kv } from "@vercel/kv";
+import { redis } from "./redis";
 
 // Rate limiter for AI Upload (5 requests per 15 minutes)
 export const aiUploadRatelimit = new Ratelimit({
-  redis: kv,
+  redis: redis,
   limiter: Ratelimit.slidingWindow(5, "900 s"),
 });
 
 // Rate limiter for Paper Requests (5 requests per 15 minutes)
 export const paperRequestRatelimit = new Ratelimit({
-  redis: kv,
+  redis: redis,
   limiter: Ratelimit.slidingWindow(5, "900 s"),
 });
 
 // Rate limiter for Subscriptions (3 requests per hour)
 export const subscribeRatelimit = new Ratelimit({
-  redis: kv,
+  redis: redis,
   limiter: Ratelimit.slidingWindow(3, "1 h"),
 });

--- a/src/lib/utils/ratelimit.ts
+++ b/src/lib/utils/ratelimit.ts
@@ -1,0 +1,20 @@
+import { Ratelimit } from "@upstash/ratelimit";
+import { kv } from "@vercel/kv";
+
+// Rate limiter for AI Upload (5 requests per 15 minutes)
+export const aiUploadRatelimit = new Ratelimit({
+  redis: kv,
+  limiter: Ratelimit.slidingWindow(5, "900 s"),
+});
+
+// Rate limiter for Paper Requests (5 requests per 15 minutes)
+export const paperRequestRatelimit = new Ratelimit({
+  redis: kv,
+  limiter: Ratelimit.slidingWindow(5, "900 s"),
+});
+
+// Rate limiter for Subscriptions (3 requests per hour)
+export const subscribeRatelimit = new Ratelimit({
+  redis: kv,
+  limiter: Ratelimit.slidingWindow(3, "1 h"),
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,23 +1,48 @@
 import { type NextRequest, NextResponse } from "next/server";
-import { Ratelimit } from "@upstash/ratelimit";
-import { kv } from "@vercel/kv";
-
-const ratelimit = new Ratelimit({
-  redis: kv,
-  limiter: Ratelimit.slidingWindow(100, "900 s"),
-});
+import {
+  aiUploadRatelimit,
+  paperRequestRatelimit,
+  subscribeRatelimit,
+} from "./lib/utils/ratelimit";
 
 export const config = {
-  matcher: "/api/upload",
+  matcher: ["/api/upload", "/api/request", "/api/subscribe"],
 };
 
 export default async function middleware(request: NextRequest) {
   const ip = request.ip ?? "127.0.0.1";
-  const { success } = await ratelimit.limit(ip);
-  return success
-    ? NextResponse.next()
-    : NextResponse.json(
+  const { pathname } = request.nextUrl;
+
+  if (pathname === "/api/upload") {
+    const { success } = await aiUploadRatelimit.limit(ip);
+    if (!success) {
+      return NextResponse.json(
         { message: "You can upload a maximum of 5 papers every 15 minutes" },
         { status: 429 },
       );
+    }
+  }
+
+  if (pathname === "/api/request") {
+    const { success } = await paperRequestRatelimit.limit(ip);
+    if (!success) {
+      return NextResponse.json(
+        { message: "You can submit a maximum of 5 requests every 15 minutes" },
+        { status: 429 },
+      );
+    }
+  }
+
+  if (pathname === "/api/subscribe") {
+    const { success } = await subscribeRatelimit.limit(ip);
+    if (!success) {
+      return NextResponse.json(
+        { message: "Maximum of 3 newsletter subscriptions per hour" },
+        { status: 429 },
+      );
+    }
+  }
+
+  return NextResponse.next();
 }
+


### PR DESCRIPTION
# feat: rate-limiting endpoints and migration to Upstash

## 📌 Purpose
This PR improves the security and scalability of the application by implementing **rate limiting** for public endpoints and migrating from Vercel KV to **Upstash Redis**. It also addresses critical Next.js deprecations and React rendering issues.

---

## Corresponding issue: closes #460  #458  #465  #455
---

## 🔧 Changes
- **Rate-limited `/request`, `/subscribe`, and `/upload`**: 
  - Implemented a sliding window rate limiter (5 requests/15 mins for papers; 3 requests/hour for newsletter) to prevent API abuse.
- **Migrated KV dependency to Upstash**: 
  - Refactored the core storage logic to remove Vercel KV and integrate Upstash Redis for better persistence and cost management.
- **Fixed `images.domains` deprecation**: 
  - Updated `next.config.js` to use `remotePatterns`, ensuring compatibility with the latest Next.js versions.
- **Fixed `useEffect` double-render**: 
  - Optimized the `Card.tsx` component logic to prevent the double-rendering issue, ensuring state only updates once on mount.

---

## ➕ Additional Notes
- **Action Required**: Add `UPSTASH_REDIS_REST_URL` and `UPSTASH_REDIS_REST_TOKEN` to your `.env` file (see `.env.example`).
- All tests were run locally with `pnpm build` to ensure no regression in the build process.

