### PR TITLE
Improve catalogue and PDF viewer UX and light mode uiux

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -71,8 +71,8 @@ const Card = ({ paper, onSelect, isSelected, isShow=true }: CardProps) => {
   window.open(paperLink, "_blank");
 }}
         className={cn(
-          "cursor-pointer overflow-hidden rounded-sm border-2 border-[#734DFF] bg-[#FFFFFF] font-play transition-all duration-150 hover:bg-[#EFEAFF] dark:border-[#36266D] dark:bg-[#171720] hover:dark:bg-[#262635]",
-          isSelected && "ring-2 ring-[#7480FF] bg-[#EFEAFF]"
+          "cursor-pointer overflow-hidden rounded-sm border-2 border-[#734DFF] bg-[#FFFFFF] font-play shadow-sm transition-all duration-150 hover:-translate-y-0.5 hover:bg-[#EFEAFF] hover:shadow-md dark:border-[#36266D] dark:bg-[#171720] dark:shadow-none hover:dark:bg-[#262635]",
+          isSelected && "-translate-y-0.5 bg-[#EFEAFF] shadow-md ring-2 ring-[#7480FF]"
         )}
       >
           <Image
@@ -171,7 +171,7 @@ const Card = ({ paper, onSelect, isSelected, isShow=true }: CardProps) => {
                   name={generateFileName(paper).replace(/\.[^.]+$/, "")}
                   className="h-full overflow-hidden"
                   height="100%"
-                  hideControls={true}
+                  hideControls={false}
                   backgroundColor="transparent"
                   hideScrollbar={true}
                 />

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -171,7 +171,7 @@ const Card = ({ paper, onSelect, isSelected, isShow=true }: CardProps) => {
                   name={generateFileName(paper).replace(/\.[^.]+$/, "")}
                   className="h-full overflow-hidden"
                   height="100%"
-                  hideControls={false}
+                  hideControls={true}
                   backgroundColor="transparent"
                   hideScrollbar={true}
                 />

--- a/src/components/CatalogueContent.tsx
+++ b/src/components/CatalogueContent.tsx
@@ -17,7 +17,7 @@ import Link from "next/link";
 import { useCourses } from "@/context/courseContext";
 import { FilterProvider, useFilters } from "@/context/filterContext";
 import EmptyState from "./ui/EmptyState";
-import SidebarButton from "./SidebarButton";
+import SelectionToolbar from "./SelectionToolbar";
 import SortComponent from "./ui/sorting";
 
 const CatalogueContentInner = ({ subject }: { subject: string | null }) => {
@@ -39,6 +39,7 @@ const CatalogueContentInner = ({ subject }: { subject: string | null }) => {
     selectedCampuses,
     selectedAnswerKeyIncluded,
     papers,
+    filteredPapers,
     appliedFilters,
     filtersPulled,
     currentPage,
@@ -60,6 +61,7 @@ const CatalogueContentInner = ({ subject }: { subject: string | null }) => {
     handleSelectAll,
     handleDeselectAll,
     handleDownloadSelected,
+    isDownloading,
   } = useFilters();
 
   useEffect(() => {
@@ -316,17 +318,14 @@ const CatalogueContentInner = ({ subject }: { subject: string | null }) => {
               currentSort={sortOption}
             />
 
-            <SidebarButton onClick={handleSelectAll} className="order-2">
-              Select All
-            </SidebarButton>
-
-            <SidebarButton onClick={handleDeselectAll} className="order-2">
-              Deselect All
-            </SidebarButton>
-
-            <SidebarButton onClick={handleDownloadSelected} className="order-2">
-              Download Selected
-            </SidebarButton>
+            <SelectionToolbar
+              selectedCount={selectedPapers.length}
+              totalCount={(appliedFilters ? filteredPapers : papers).length}
+              onSelectAll={handleSelectAll}
+              onDeselectAll={handleDeselectAll}
+              onDownload={() => void handleDownloadSelected()}
+              isDownloading={isDownloading}
+            />
           </div>
 
           {relatedSubjects.length > 0 && (

--- a/src/components/SelectionToolbar.tsx
+++ b/src/components/SelectionToolbar.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import React from "react";
+import { CheckSquare, Square, Download, Loader2 } from "lucide-react";
+import { cn } from "@/lib/utils";
+
+interface SelectionToolbarProps {
+  selectedCount: number;
+  totalCount: number;
+  onSelectAll: () => void;
+  onDeselectAll: () => void;
+  onDownload: () => void;
+  isDownloading: boolean;
+}
+
+const SelectionToolbar: React.FC<SelectionToolbarProps> = ({
+  selectedCount,
+  totalCount,
+  onSelectAll,
+  onDeselectAll,
+  onDownload,
+  isDownloading,
+}) => {
+  const allSelected = totalCount > 0 && selectedCount === totalCount;
+  const hasSelection = selectedCount > 0;
+
+  return (
+    <div className="flex items-center gap-2 rounded-full border-2 border-black bg-white p-1 pl-3 font-play text-xs font-semibold shadow-[2px_2px_0_0_#000] dark:border-[#434dba] dark:bg-[#0a0118] dark:shadow-[2px_2px_0_0_#434dba]">
+      <span
+        className={cn(
+          "min-w-[64px] select-none text-gray-500 transition-colors dark:text-gray-400",
+          hasSelection && "text-[#5B4CDB] dark:text-[#B2B8FF]",
+        )}
+      >
+        {selectedCount} / {totalCount} selected
+      </span>
+
+      <div className="h-5 w-px bg-black/10 dark:bg-white/10" />
+
+      <button
+        type="button"
+        onClick={allSelected ? onDeselectAll : onSelectAll}
+        className="flex items-center gap-1.5 rounded-full px-3 py-1.5 transition-colors hover:bg-[#B2B8FF] hover:text-black dark:hover:bg-[#434dba] dark:hover:text-white"
+        aria-pressed={allSelected}
+      >
+        {allSelected ? (
+          <CheckSquare size={16} className="text-[#7480FF]" />
+        ) : (
+          <Square size={16} />
+        )}
+        <span className="hidden sm:inline">
+          {allSelected ? "Deselect All" : "Select All"}
+        </span>
+        <span className="sm:hidden">{allSelected ? "None" : "All"}</span>
+      </button>
+
+      <button
+        type="button"
+        onClick={onDownload}
+        disabled={!hasSelection || isDownloading}
+        aria-busy={isDownloading}
+        className={cn(
+          "flex items-center gap-1.5 rounded-full bg-black px-3 py-1.5 text-white transition-colors dark:bg-[#7480FF]",
+          hasSelection && !isDownloading
+            ? "hover:bg-[#7480FF] dark:hover:bg-[#B2B8FF] dark:hover:text-black"
+            : "cursor-not-allowed opacity-40",
+        )}
+      >
+        {isDownloading ? (
+          <Loader2 size={16} className="animate-spin" />
+        ) : (
+          <Download size={16} />
+        )}
+        <span className="hidden sm:inline">
+          {isDownloading
+            ? "Zipping…"
+            : hasSelection
+              ? `Download (${selectedCount})`
+              : "Download Selected"}
+        </span>
+        <span className="sm:hidden">
+          {isDownloading ? "Zipping…" : `Download${hasSelection ? ` (${selectedCount})` : ""}`}
+        </span>
+      </button>
+    </div>
+  );
+};
+
+export default SelectionToolbar;

--- a/src/components/newPdfViewer.tsx
+++ b/src/components/newPdfViewer.tsx
@@ -9,7 +9,7 @@ import { useZoom, ZoomPluginPackage, ZoomMode }          from '@embedpdf/plugin-
 import { RenderLayer, RenderPluginPackage }              from '@embedpdf/plugin-render/react';
 import { ExportPluginPackage }                           from '@embedpdf/plugin-export/react';
 
-import { Download, ZoomIn, ZoomOut, Maximize2, Minimize2 } from "lucide-react";
+import { Download, ZoomIn, ZoomOut, Maximize2, Minimize2, BookOpenText, X } from "lucide-react";
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import { downloadFile } from "../lib/utils/download";
 import { Button } from "./ui/button";
@@ -26,6 +26,10 @@ interface ControlProps {
   isMobile: boolean;
   isSmall: boolean;
   viewerRef: React.RefObject<HTMLDivElement>;
+  isReadingMode: boolean;
+  toggleReadingMode: () => void;
+  showReadingCoachmark: boolean;
+  dismissReadingCoachmark: () => void;
 }
 
 interface PdfViewerProps {
@@ -37,6 +41,7 @@ interface PdfViewerProps {
   backgroundColor?: string;
   hideScrollbar?: boolean;
   isolateFromTheme?: boolean;
+  onReadingModeChange?: (isReadingMode: boolean) => void;
 }
 
 interface WheelZoomProps {
@@ -58,7 +63,8 @@ function useBreakpoint() {
 }
 
 const Controls = memo(function Controls({documentId, toggleFullscreen, isFullscreen, onDownload,
-  forceMobile, isMobile, isSmall, viewerRef}: ControlProps) {
+  forceMobile, isMobile, isSmall, viewerRef, isReadingMode, toggleReadingMode,
+  showReadingCoachmark, dismissReadingCoachmark}: ControlProps) {
 
   const { provides: zoomProv, state: zoomState } = useZoom(documentId);
   const { provides: scrollProv, state: scrollState } = useScroll(documentId);
@@ -110,6 +116,23 @@ const pageChange = useCallback(
 
   if (!zoomProv || !scrollProv) return null;
 
+  if (isReadingMode) {
+    return (
+      <button
+        onClick={toggleReadingMode}
+        title="Exit Reading Mode (R)"
+        className="group fixed bottom-5 left-1/2 z-[2] flex -translate-x-1/2 items-center gap-2 rounded-full bg-[#262635]/70 py-1.5 pl-3.5 pr-2 text-xs font-medium text-white/70 shadow-lg backdrop-blur transition-all hover:bg-[#262635] hover:text-white hover:opacity-100"
+        style={{ opacity: 0.55 }}
+      >
+        <BookOpenText size={13} />
+        Reading Mode
+        <span className="ml-1 flex h-5 w-5 items-center justify-center rounded-full bg-white/10 group-hover:bg-[#6536c1]">
+          <X size={11} />
+        </span>
+      </button>
+    );
+  }
+
   const zoomIn = () => zoomProv.zoomIn();
   const zoomOut = () => zoomProv.zoomOut();
   const { zoomLevel } = zoomState;
@@ -146,6 +169,35 @@ const pageChange = useCallback(
   
   const toolSet = (
     <>
+      <div className="relative">
+        {showReadingCoachmark && (
+          <div className="absolute bottom-full right-0 z-[2] mb-3 w-52 animate-in fade-in slide-in-from-bottom-1 duration-300">
+            <div className="rounded-lg bg-[#6536c1] px-3 py-2.5 text-[11px] leading-snug text-white shadow-xl">
+              <span className="font-semibold">New: Reading Mode.</span> Hides
+              everything but the paper — lighter than Fullscreen, your tabs
+              stay put.
+              <button
+                onClick={dismissReadingCoachmark}
+                className="mt-1.5 block text-[10px] font-semibold underline underline-offset-2"
+              >
+                Got it
+              </button>
+            </div>
+            <div className="ml-auto mr-3.5 h-2 w-2 -translate-y-1 rotate-45 bg-[#6536c1]" />
+          </div>
+        )}
+        {showReadingCoachmark && (
+          <span className="absolute inset-0 animate-ping rounded bg-[#6536c1] opacity-40" />
+        )}
+        <Button
+          onClick={toggleReadingMode}
+          className="relative h-10 w-10 rounded p-0 text-white bg-[#6536c1] transition hover:bg-[#7d4fc7]"
+          title="Reading Mode (R) — show just the paper"
+        >
+          <BookOpenText size={24} />
+        </Button>
+      </div>
+
       <Button
       onClick={toggleFullscreen}
       className="h-10 w-10 rounded p-0 text-white bg-[#6536c1] transition hover:bg-[#7d4fc7]"
@@ -406,11 +458,14 @@ export default function PDFViewer({
   backgroundColor,
   hideScrollbar = false,
   isolateFromTheme = true,
+  onReadingModeChange,
 }: PdfViewerProps) {
   const { engine, isLoading } = usePdfiumEngine();
   const { isMobile, isSmall } = useBreakpoint();
   const { resolvedTheme } = useTheme();
   const [isFullscreen, setIsFullscreen] = useState(false);
+  const [isReadingMode, setIsReadingMode] = useState(false);
+  const [showReadingCoachmark, setShowReadingCoachmark] = useState(false);
   const viewerRef = useRef<HTMLDivElement>(null);
   const effectiveBackgroundColor =
     backgroundColor ?? (resolvedTheme === "light" ? "#F3F5FF" : "#070114");
@@ -440,6 +495,59 @@ export default function PDFViewer({
     document.addEventListener("fullscreenchange", handleFullscreenChange);
     return () => document.removeEventListener("fullscreenchange", handleFullscreenChange);
   }, []);
+
+  const dismissReadingCoachmark = useCallback(() => {
+    setShowReadingCoachmark(false);
+    try {
+      window.localStorage.setItem("pdfReadingModeSeen", "1");
+    } catch {
+      // localStorage unavailable (private mode, etc) — coachmark just won't persist
+    }
+  }, []);
+
+  const toggleReadingMode = useCallback(() => {
+    setIsReadingMode((r) => {
+      const next = !r;
+      onReadingModeChange?.(next);
+      return next;
+    });
+    dismissReadingCoachmark();
+  }, [dismissReadingCoachmark, onReadingModeChange]);
+
+  useEffect(() => {
+    try {
+      if (!window.localStorage.getItem("pdfReadingModeSeen")) {
+        setShowReadingCoachmark(true);
+      }
+    } catch {
+      // ignore
+    }
+  }, []);
+
+  useEffect(() => {
+    if (!isReadingMode) return;
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [isReadingMode]);
+
+  useEffect(() => {
+    const handleKeydown = (e: KeyboardEvent) => {
+      const target = e.target as HTMLElement | null;
+      if (target && ["INPUT", "TEXTAREA"].includes(target.tagName)) return;
+
+      if (e.key === "r" || e.key === "R") {
+        toggleReadingMode();
+      } else if (e.key === "Escape" && isReadingMode) {
+        setIsReadingMode(false);
+        onReadingModeChange?.(false);
+      }
+    };
+    window.addEventListener("keydown", handleKeydown);
+    return () => window.removeEventListener("keydown", handleKeydown);
+  }, [isReadingMode, toggleReadingMode, onReadingModeChange]);
 
   const plugins = useMemo(() => [
     createPluginRegistration(DocumentManagerPluginPackage, {
@@ -503,14 +611,20 @@ if (isLoading || !engine) {
         data-pdf-viewer-scrollbars={hideScrollbar ? "hidden" : "visible"}
         className={className}
         style={{
-          height,
+          height: isReadingMode ? "100dvh" : height,
           width: "100%",
-          position: "relative",
+          position: isReadingMode ? "fixed" : "relative",
+          top: isReadingMode ? 0 : undefined,
+          left: isReadingMode ? 0 : undefined,
+          right: isReadingMode ? 0 : undefined,
+          bottom: isReadingMode ? 0 : undefined,
+          zIndex: isReadingMode ? 999 : undefined,
           backgroundColor: effectiveBackgroundColor,
           display: "flex",
           flexDirection: "column",
           colorScheme: isolateFromTheme ? "light" : undefined,
           forcedColorAdjust: isolateFromTheme ? "none" : undefined,
+          transition: "height 0.2s ease",
         }}
       >
         <EmbedPDF engine={engine} plugins={plugins}>
@@ -528,6 +642,10 @@ if (isLoading || !engine) {
                 isMobile={isMobile}
                 isSmall={isSmall}
                 viewerRef={viewerRef}
+                isReadingMode={isReadingMode}
+                toggleReadingMode={toggleReadingMode}
+                showReadingCoachmark={showReadingCoachmark}
+                dismissReadingCoachmark={dismissReadingCoachmark}
               />}
               <DocumentContent documentId={activeDocumentId}>
                 {({ isLoaded }) => (
@@ -579,6 +697,10 @@ if (isLoading || !engine) {
                   isMobile={isMobile}
                   isSmall={isSmall}
                   viewerRef={viewerRef}
+                  isReadingMode={isReadingMode}
+                  toggleReadingMode={toggleReadingMode}
+                  showReadingCoachmark={showReadingCoachmark}
+                  dismissReadingCoachmark={dismissReadingCoachmark}
                 />
               )}
             </>

--- a/src/components/newPdfViewer.tsx
+++ b/src/components/newPdfViewer.tsx
@@ -192,7 +192,7 @@
           <Button
             onClick={toggleReadingMode}
             className="relative h-10 w-10 rounded p-0 text-white bg-[#6536c1] transition hover:bg-[#7d4fc7]"
-            title="Reading Mode (R) — show just the paper"
+            title="Reading Mode (R): show just the paper"
           >
             <BookOpenText size={24} />
           </Button>

--- a/src/components/newPdfViewer.tsx
+++ b/src/components/newPdfViewer.tsx
@@ -1,699 +1,644 @@
-"use client"
-import { createPluginRegistration } from '@embedpdf/core';
-import { EmbedPDF }                 from '@embedpdf/core/react';
-import { usePdfiumEngine }          from '@embedpdf/engines/react';
-import { Viewport, ViewportPluginPackage }               from '@embedpdf/plugin-viewport/react';
-import { useScroll, useScrollCapability, Scroller, ScrollPluginPackage } from '@embedpdf/plugin-scroll/react';
-import { DocumentContent, DocumentManagerPluginPackage } from '@embedpdf/plugin-document-manager/react';
-import { useZoom, ZoomPluginPackage, ZoomMode }          from '@embedpdf/plugin-zoom/react';
-import { RenderLayer, RenderPluginPackage }              from '@embedpdf/plugin-render/react';
-import { ExportPluginPackage }                           from '@embedpdf/plugin-export/react';
+  "use client"
+  import { createPluginRegistration } from '@embedpdf/core';
+  import { EmbedPDF }                 from '@embedpdf/core/react';
+  import { usePdfiumEngine }          from '@embedpdf/engines/react';
+  import { Viewport, ViewportPluginPackage }               from '@embedpdf/plugin-viewport/react';
+  import { useScroll, useScrollCapability, Scroller, ScrollPluginPackage } from '@embedpdf/plugin-scroll/react';
+  import { DocumentContent, DocumentManagerPluginPackage } from '@embedpdf/plugin-document-manager/react';
+  import { useZoom, ZoomPluginPackage, ZoomMode }          from '@embedpdf/plugin-zoom/react';
+  import { RenderLayer, RenderPluginPackage }              from '@embedpdf/plugin-render/react';
+  import { ExportPluginPackage }                           from '@embedpdf/plugin-export/react';
 
-import { Download, ZoomIn, ZoomOut, Maximize2, Minimize2, BookOpenText, X } from "lucide-react";
-import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
-import { downloadFile } from "../lib/utils/download";
-import { Button } from "./ui/button";
-import ShareButton from "./ShareButton";
-import ReportButton from "./ReportButton";
-import { useTheme } from "next-themes";
+  import { Download, ZoomIn, ZoomOut, Maximize2, Minimize2, BookOpenText, X } from "lucide-react";
+  import { memo, useCallback, useEffect, useMemo, useRef, useState } from "react";
+  import { downloadFile } from "../lib/utils/download";
+  import { Button } from "./ui/button";
+  import ShareButton from "./ShareButton";
+  import ReportButton from "./ReportButton";
+  import { useTheme } from "next-themes";
 
-interface ControlProps {
-  documentId: string;
-  toggleFullscreen: () => void;
-  isFullscreen: boolean;
-  onDownload: () => Promise<void>;
-  forceMobile?: boolean;
-  isMobile: boolean;
-  isSmall: boolean;
-  viewerRef: React.RefObject<HTMLDivElement>;
-  isReadingMode: boolean;
-  toggleReadingMode: () => void;
-  showReadingCoachmark: boolean;
-  dismissReadingCoachmark: () => void;
-}
+  interface ControlProps {
+    documentId: string;
+    toggleFullscreen: () => void;
+    isFullscreen: boolean;
+    onDownload: () => Promise<void>;
+    forceMobile?: boolean;
+    isMobile: boolean;
+    isSmall: boolean;
+    viewerRef: React.RefObject<HTMLDivElement>;
+    isReadingMode: boolean;
+    toggleReadingMode: () => void;
+    showReadingCoachmark: boolean;
+    dismissReadingCoachmark: () => void;
+  }
 
-interface PdfViewerProps {
-  url: string;
-  name: string;
-  className?: string;
-  height?: string;
-  hideControls?: boolean;
-  backgroundColor?: string;
-  hideScrollbar?: boolean;
-  isolateFromTheme?: boolean;
-  onReadingModeChange?: (isReadingMode: boolean) => void;
-}
+  interface PdfViewerProps {
+    url: string;
+    name: string;
+    className?: string;
+    height?: string;
+    hideControls?: boolean;
+    backgroundColor?: string;
+    hideScrollbar?: boolean;
+    isolateFromTheme?: boolean;
+    onReadingModeChange?: (isReadingMode: boolean) => void;
+  }
 
-interface WheelZoomProps {
-  documentId: string;
-  viewerRef: React.RefObject<HTMLDivElement>;
-}
+  interface WheelZoomProps {
+    documentId: string;
+    viewerRef: React.RefObject<HTMLDivElement>;
+  }
 
-function useBreakpoint() {
-  const [width, setWidth] = useState<number | null>(null);
+  function useBreakpoint() {
+    const [width, setWidth] = useState<number | null>(null);
 
-  useEffect(() => {
-    setWidth(window.innerWidth);
-    const handler = () => setWidth(window.innerWidth);
-    window.addEventListener("resize", handler);
-    return () => window.removeEventListener("resize", handler);
-  }, []);
-  
-  return {isMobile: width !== null && width < 768, isSmall: width !== null && width < 640};
-}
+    useEffect(() => {
+      setWidth(window.innerWidth);
+      const handler = () => setWidth(window.innerWidth);
+      window.addEventListener("resize", handler);
+      return () => window.removeEventListener("resize", handler);
+    }, []);
+    
+    return {isMobile: width !== null && width < 768, isSmall: width !== null && width < 640};
+  }
 
-const Controls = memo(function Controls({documentId, toggleFullscreen, isFullscreen, onDownload,
-  forceMobile, isMobile, isSmall, viewerRef, isReadingMode, toggleReadingMode,
-  showReadingCoachmark, dismissReadingCoachmark}: ControlProps) {
+  const Controls = memo(function Controls({documentId, toggleFullscreen, isFullscreen, onDownload,
+    forceMobile, isMobile, isSmall, viewerRef, isReadingMode, toggleReadingMode,
+    showReadingCoachmark, dismissReadingCoachmark}: ControlProps) {
 
-  const { provides: zoomProv, state: zoomState } = useZoom(documentId);
-  const { provides: scrollProv, state: scrollState } = useScroll(documentId);
-  const { provides: scrollCapability } = useScrollCapability();
-  const [pageNo, setPageNo] = useState("1");
-  const [totalPages, setTotalPages] = useState(0);
-  const editingRef = useRef(false);
+    const { provides: zoomProv, state: zoomState } = useZoom(documentId);
+    const { provides: scrollProv, state: scrollState } = useScroll(documentId);
+    const { provides: scrollCapability } = useScrollCapability();
+    const [pageNo, setPageNo] = useState("1");
+    const [totalPages, setTotalPages] = useState(0);
+    const editingRef = useRef(false);
 
-  useEffect(() => {
-    if (!scrollCapability) return;
-    const unsub = scrollCapability.onLayoutReady((event) => {
-      if (event.documentId === documentId) {
+    useEffect(() => {
+      if (!scrollCapability) return;
+      const unsub = scrollCapability.onLayoutReady((event) => {
+        if (event.documentId === documentId) {
+          setTotalPages(event.totalPages);
+        }
+      });
+      return () => {
+        unsub();
+        setTotalPages(0);
+      };
+    }, [scrollCapability, documentId]);
+
+    useEffect(() => {
+      if (!scrollProv) return;
+      const unsub = scrollProv.onPageChange((event) => {
         setTotalPages(event.totalPages);
-      }
-    });
-    return () => {
-      unsub();
-      setTotalPages(0);
-    };
-  }, [scrollCapability, documentId]);
-
-  useEffect(() => {
-    if (!scrollProv) return;
-    const unsub = scrollProv.onPageChange((event) => {
-      setTotalPages(event.totalPages);
-      if (!editingRef.current) {
-        setPageNo(String(event.pageNumber));
-      }
-    });
-    return () => unsub();
-  }, [scrollProv]);
-  
-  const effectiveTotalPages =
-    totalPages > 0 ? totalPages : (scrollState?.totalPages ?? 0);
-  
-const pageChange = useCallback(
-    (e: React.KeyboardEvent<HTMLInputElement>) => {
-      if (e.key !== "Enter") return;
-      const page = parseInt(pageNo, 10);
-      if (isNaN(page)) return;
-      if (page >= 1 && page <= effectiveTotalPages) {
-        scrollProv?.scrollToPage({ pageNumber: page, behavior: "smooth" });
-      } else {
-        setPageNo(String(scrollProv?.getCurrentPage() ?? 1));
-      }
-    },
-    [pageNo, effectiveTotalPages, scrollProv]
-  );
-
-  if (!zoomProv || !scrollProv) return null;
-
-  if (isReadingMode) {
-    return (
-      <button
-        onClick={toggleReadingMode}
-        title="Exit Reading Mode (R)"
-        className="group fixed bottom-5 left-1/2 z-[2] flex -translate-x-1/2 items-center gap-2 rounded-full bg-[#262635]/70 py-1.5 pl-3.5 pr-2 text-xs font-medium text-white/70 shadow-lg backdrop-blur transition-all hover:bg-[#262635] hover:text-white hover:opacity-100"
-        style={{ opacity: 0.55 }}
-      >
-        <BookOpenText size={13} />
-        Reading Mode
-        <span className="ml-1 flex h-5 w-5 items-center justify-center rounded-full bg-white/10 group-hover:bg-[#6536c1]">
-          <X size={11} />
-        </span>
-      </button>
+        if (!editingRef.current) {
+          setPageNo(String(event.pageNumber));
+        }
+      });
+      return () => unsub();
+    }, [scrollProv]);
+    
+    const effectiveTotalPages =
+      totalPages > 0 ? totalPages : (scrollState?.totalPages ?? 0);
+    
+  const pageChange = useCallback(
+      (e: React.KeyboardEvent<HTMLInputElement>) => {
+        if (e.key !== "Enter") return;
+        const page = parseInt(pageNo, 10);
+        if (isNaN(page)) return;
+        if (page >= 1 && page <= effectiveTotalPages) {
+          scrollProv?.scrollToPage({ pageNumber: page, behavior: "smooth" });
+        } else {
+          setPageNo(String(scrollProv?.getCurrentPage() ?? 1));
+        }
+      },
+      [pageNo, effectiveTotalPages, scrollProv]
     );
-  }
 
-  const zoomIn = () => zoomProv.zoomIn();
-  const zoomOut = () => zoomProv.zoomOut();
-  const { zoomLevel } = zoomState;
-  const fullScreenStyle = {
-    bottom: 20,
-    left: "50%",
-    transform: "translateX(-50%)",
-  }
+    if (!zoomProv || !scrollProv) return null;
 
-  const pageInput = (
-    <div className={(!isFullscreen && !isMobile) ? "flex flex-col items-center gap-2" : "flex flex-row items-center gap-2"}>
-        <input
-          type="text"
-          value={pageNo}
-          onChange={(e) => {
-            editingRef.current = true;
-            setPageNo(e.target.value.replace(/[^0-9]/g, ""));
-          }}
-          onKeyDown={pageChange}
-          onFocus={(e) => {
-            editingRef.current = true;
-            e.target.select();
-          }}
-          onBlur={() => {
-            editingRef.current = false;
-            setPageNo(String(scrollProv?.getCurrentPage() ?? 1));
-          }}
-          inputMode="numeric"
-          className="h-9 w-14 rounded border bg-[#e7e9ff] p-1 text-center text-sm [appearance:textfield] dark:bg-[#1f1f2a] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
-        />
-        <span className="text-xs font-medium text-white">of {totalPages ?? 1}</span>
-    </div>
-  )
-  
-  const toolSet = (
-    <>
-      <div className="relative">
-        {showReadingCoachmark && (
-          <div className="absolute bottom-full right-0 z-[2] mb-3 w-52 animate-in fade-in slide-in-from-bottom-1 duration-300">
-            <div className="rounded-lg bg-[#6536c1] px-3 py-2.5 text-[11px] leading-snug text-white shadow-xl">
-              <span className="font-semibold">New: Reading Mode.</span> Hides
-              everything but the paper — lighter than Fullscreen, your tabs
-              stay put.
-              <button
-                onClick={dismissReadingCoachmark}
-                className="mt-1.5 block text-[10px] font-semibold underline underline-offset-2"
-              >
-                Got it
-              </button>
-            </div>
-            <div className="ml-auto mr-3.5 h-2 w-2 -translate-y-1 rotate-45 bg-[#6536c1]" />
-          </div>
-        )}
-        {showReadingCoachmark && (
-          <span className="absolute inset-0 animate-ping rounded bg-[#6536c1] opacity-40" />
-        )}
-        <Button
+    if (isReadingMode) {
+      return (
+        <button
           onClick={toggleReadingMode}
-          className="relative h-10 w-10 rounded p-0 text-white bg-[#6536c1] transition hover:bg-[#7d4fc7]"
-          title="Reading Mode (R) — show just the paper"
+          title="Exit Reading Mode (R)"
+          className="group fixed bottom-5 left-1/2 z-[2] flex -translate-x-1/2 items-center gap-2 rounded-full bg-[#262635]/70 py-1.5 pl-3.5 pr-2 text-xs font-medium text-white/70 shadow-lg backdrop-blur transition-all hover:bg-[#262635] hover:text-white hover:opacity-100"
+          style={{ opacity: 0.55 }}
         >
-          <BookOpenText size={24} />
-        </Button>
+          <BookOpenText size={13} />
+          Reading Mode
+          <span className="ml-1 flex h-5 w-5 items-center justify-center rounded-full bg-white/10 group-hover:bg-[#6536c1]">
+            <X size={11} />
+          </span>
+        </button>
+      );
+    }
+
+    const zoomIn = () => zoomProv.zoomIn();
+    const zoomOut = () => zoomProv.zoomOut();
+    const { zoomLevel } = zoomState;
+    const fullScreenStyle = {
+      bottom: 20,
+      left: "50%",
+      transform: "translateX(-50%)",
+    }
+
+    const pageInput = (
+      <div className={(!isFullscreen && !isMobile) ? "flex flex-col items-center gap-2" : "flex flex-row items-center gap-2"}>
+          <input
+            type="text"
+            value={pageNo}
+            onChange={(e) => {
+              editingRef.current = true;
+              setPageNo(e.target.value.replace(/[^0-9]/g, ""));
+            }}
+            onKeyDown={pageChange}
+            onFocus={(e) => {
+              editingRef.current = true;
+              e.target.select();
+            }}
+            onBlur={() => {
+              editingRef.current = false;
+              setPageNo(String(scrollProv?.getCurrentPage() ?? 1));
+            }}
+            inputMode="numeric"
+            className="h-9 w-14 rounded border bg-[#e7e9ff] p-1 text-center text-sm [appearance:textfield] dark:bg-[#1f1f2a] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
+          />
+          <span className="text-xs font-medium text-white">of {totalPages ?? 1}</span>
       </div>
-
-      <Button
-      onClick={toggleFullscreen}
-      className="h-10 w-10 rounded p-0 text-white bg-[#6536c1] transition hover:bg-[#7d4fc7]"
-      title={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
-      >
-      {isFullscreen ? <Minimize2 size={24} /> : <Maximize2 size={24} />}
-      </Button>
-
-      <Button
-        onClick={onDownload}
-        className="h-10 w-10 rounded p-0 text-white bg-[#6536c1] transition hover:bg-[#7d4fc7]"
-        title="Download PDF"
-      >
-        <Download size={24} />
-      </Button>
-
-      <ShareButton isFullscreen={isFullscreen} viewerRef={viewerRef} />
-
-      <Button
-        onClick={zoomOut}
-        disabled={typeof zoomLevel === "number" && zoomLevel <= 0.25}
-        className="h-10 w-10 rounded p-0 text-white bg-[#6536c1] transition hover:bg-[#7d4fc7] disabled:bg-gray-400"
-        title="Zoom out"
-      >
-        <ZoomOut size={24} />
-      </Button>
-
-      <span className="text-xs text-[16.5px] py-2 text-white font-small bg-[#262635] rounded px-1">
-        {typeof zoomLevel === "number" ? `${Math.round(zoomLevel * 100)}%` : "100%"}
-      </span>
-
-      <Button
-        onClick={zoomIn}
-        disabled={typeof zoomLevel === "number" && zoomLevel >= 3}
-        className="h-10 w-10 rounded p-0 text-white bg-[#6536c1] transition hover:bg-[#7d4fc7] disabled:bg-gray-400"
-        title="Zoom in"
-      >
-        <ZoomIn size={24} />
-      </Button>
-
-      {isSmall && <ReportButton/>}
-
-    </>
-  )
-
-  if (!forceMobile) {
-    return (
+    )
+    
+    const toolSet = (
       <>
-      {!isSmall ? 
-        <div
-          style={{
-            position: "absolute",
-            ...(isFullscreen ? {...fullScreenStyle, flexDirection: "row"} : {
-              top: "40%",
-              right: 20,
-              transform: "translateY(-50%)",
-              flexDirection: "column" as const,
-            }),
-            zIndex: 1,
-            padding: "10px 8px",
-            display: "flex",
-            gap: 16,
-            alignItems: "center",
-            alignSelf: "center",
-            width: isFullscreen ? "auto" : "96px",
-            background: "#262635",
-            borderRadius: 8,
-            backdropFilter: "blur(6px)",
-          }}
+        <div className="relative">
+          {showReadingCoachmark && (
+            <div className="absolute bottom-full right-0 z-[2] mb-3 w-52 animate-in fade-in slide-in-from-bottom-1 duration-300">
+              <div className="rounded-lg bg-[#6536c1] px-3 py-2.5 text-[11px] leading-snug text-white shadow-xl">
+                <span className="font-semibold">New: Reading Mode.</span> Hides
+                everything but the paper — lighter than Fullscreen, your tabs
+                stay put.
+                <button
+                  onClick={dismissReadingCoachmark}
+                  className="mt-1.5 block text-[10px] font-semibold underline underline-offset-2"
+                >
+                  Got it
+                </button>
+              </div>
+              <div className="ml-auto mr-3.5 h-2 w-2 -translate-y-1 rotate-45 bg-[#6536c1]" />
+            </div>
+          )}
+          {showReadingCoachmark && (
+            <span className="absolute inset-0 animate-ping rounded bg-[#6536c1] opacity-40" />
+          )}
+          <Button
+            onClick={toggleReadingMode}
+            className="relative h-10 w-10 rounded p-0 text-white bg-[#6536c1] transition hover:bg-[#7d4fc7]"
+            title="Reading Mode (R) — show just the paper"
+          >
+            <BookOpenText size={24} />
+          </Button>
+        </div>
+
+        <Button
+        onClick={toggleFullscreen}
+        className="h-10 w-10 rounded p-0 text-white bg-[#6536c1] transition hover:bg-[#7d4fc7]"
+        title={isFullscreen ? "Exit fullscreen" : "Enter fullscreen"}
         >
-          {toolSet}
-          {pageInput}
-          {!isSmall && <ReportButton />}
-        </div> : 
-        <div
-          style={{
-            position: "absolute",
-            ...(isFullscreen ? fullScreenStyle : {
-              top: "40%",
-              right: 20,
-              transform: "translateY(-50%)",
-            }),
-            flexDirection: "column" as const,
-            zIndex: 1,
-            padding: "20px 12px",
-            display: "flex",
-            gap: 16,
-            alignItems: "center",
-            alignSelf: "center",
-            width: isFullscreen ? "auto" : "96px",
-            background: "#262635",
-            borderRadius: 8,
-            backdropFilter: "blur(6px)",
-          }}
-        >       
-          {pageInput}
+        {isFullscreen ? <Minimize2 size={24} /> : <Maximize2 size={24} />}
+        </Button>
+
+        <Button
+          onClick={onDownload}
+          className="h-10 w-10 rounded p-0 text-white bg-[#6536c1] transition hover:bg-[#7d4fc7]"
+          title="Download PDF"
+        >
+          <Download size={24} />
+        </Button>
+
+        <ShareButton isFullscreen={isFullscreen} viewerRef={viewerRef} />
+
+        <Button
+          onClick={zoomOut}
+          disabled={typeof zoomLevel === "number" && zoomLevel <= 0.25}
+          className="h-10 w-10 rounded p-0 text-white bg-[#6536c1] transition hover:bg-[#7d4fc7] disabled:bg-gray-400"
+          title="Zoom out"
+        >
+          <ZoomOut size={24} />
+        </Button>
+
+        <span className="text-xs text-[16.5px] py-2 text-white font-small bg-[#262635] rounded px-1">
+          {typeof zoomLevel === "number" ? `${Math.round(zoomLevel * 100)}%` : "100%"}
+        </span>
+
+        <Button
+          onClick={zoomIn}
+          disabled={typeof zoomLevel === "number" && zoomLevel >= 3}
+          className="h-10 w-10 rounded p-0 text-white bg-[#6536c1] transition hover:bg-[#7d4fc7] disabled:bg-gray-400"
+          title="Zoom in"
+        >
+          <ZoomIn size={24} />
+        </Button>
+
+        {isSmall && <ReportButton/>}
+
+      </>
+    )
+
+    if (!forceMobile) {
+      return (
+        <>
+        {!isSmall ? 
           <div
             style={{
+              position: "absolute",
+              ...(isFullscreen ? {...fullScreenStyle, flexDirection: "row"} : {
+                top: "40%",
+                right: 20,
+                transform: "translateY(-50%)",
+                flexDirection: "column" as const,
+              }),
+              zIndex: 1,
+              padding: "10px 8px",
               display: "flex",
-              flexDirection: isFullscreen ? "row" as const : "column" as const,
               gap: 16,
               alignItems: "center",
+              alignSelf: "center",
+              width: isFullscreen ? "auto" : "96px",
+              background: "#262635",
+              borderRadius: 8,
+              backdropFilter: "blur(6px)",
             }}
           >
             {toolSet}
-          </div>
-          
-        </div>}
-      </>
-      
+            {pageInput}
+            {!isSmall && <ReportButton />}
+          </div> : 
+          <div
+            style={{
+              position: "absolute",
+              ...(isFullscreen ? fullScreenStyle : {
+                top: "40%",
+                right: 20,
+                transform: "translateY(-50%)",
+              }),
+              flexDirection: "column" as const,
+              zIndex: 1,
+              padding: "20px 12px",
+              display: "flex",
+              gap: 16,
+              alignItems: "center",
+              alignSelf: "center",
+              width: isFullscreen ? "auto" : "96px",
+              background: "#262635",
+              borderRadius: 8,
+              backdropFilter: "blur(6px)",
+            }}
+          >       
+            {pageInput}
+            <div
+              style={{
+                display: "flex",
+                flexDirection: isFullscreen ? "row" as const : "column" as const,
+                gap: 16,
+                alignItems: "center",
+              }}
+            >
+              {toolSet}
+            </div>
+            
+          </div>}
+        </>
+        
+      );
+    }
+
+    return(
+      <div
+        style={{
+          top: "40%",
+          flexDirection: isSmall ? "column" : "row",
+          zIndex: 1,
+          padding: "10px 12px",
+          display: "flex",
+          gap: 16,
+          alignItems: "center",
+          alignSelf: "center",
+          width: "auto",
+          background: "#262635",
+          borderRadius: 12,
+          backdropFilter: "blur(6px)",
+        }}
+      > 
+        {isSmall ? (
+          <>
+            {pageInput}
+            <div style={{ display: "flex", flexDirection: "row", gap: 16, alignItems: "center" }}>
+              {toolSet}
+            </div>
+          </>
+        ) : (
+          <>
+            {toolSet}
+            {pageInput}
+            <ReportButton />
+          </>
+        )}
+      </div>
+    )
+  });
+
+  function WheelZoom({ documentId, viewerRef }: WheelZoomProps) {
+    const { provides: zoomProv } = useZoom(documentId);
+    const accumulatedDelta = useRef(0);
+    const rafId = useRef<number | null>(null);
+    const curZoom = useRef(1);
+
+    useEffect(() => {
+      if (!zoomProv) return;
+      curZoom.current = zoomProv.getState().currentZoomLevel;
+      const unsub = zoomProv.onZoomChange((e) => {
+        curZoom.current = e.newZoom;
+      });
+      return unsub;
+    }, [zoomProv]);
+
+    const handleWheel = useCallback(
+      (e: WheelEvent) => {
+        if (!e.ctrlKey || !zoomProv) return;
+        e.preventDefault();
+
+        const isTrackpad = Math.abs(e.deltaY) < 50;
+        const scaleFactor = isTrackpad ? 0.008 : 0.08;
+        accumulatedDelta.current += -e.deltaY * scaleFactor;
+
+        if (rafId.current !== null) cancelAnimationFrame(rafId.current);
+        rafId.current = requestAnimationFrame(() => {
+          const clamped = Math.max(-0.15, Math.min(accumulatedDelta.current, 0.15));
+
+          if (isTrackpad) {
+            const target = Math.max(0.25, Math.min(curZoom.current + clamped, 4));
+            zoomProv.requestZoom(target)
+            curZoom.current = target;
+          } else {
+            zoomProv.requestZoomBy(clamped);
+          }
+
+          accumulatedDelta.current = 0;
+          rafId.current = null;
+        });
+      },
+      [zoomProv]
+    );
+
+    useEffect(() => {
+      const viewer = viewerRef.current;
+      if (!viewer) return;
+      viewer.addEventListener("wheel", handleWheel, { passive: false });
+      return () => {
+        viewer.removeEventListener("wheel", handleWheel);
+        if (rafId.current !== null) cancelAnimationFrame(rafId.current);
+      };
+    }, [handleWheel, viewerRef]);
+
+    return null;
+  }
+
+  function useLoadingMessage(messages: string[], interval = 2200) {
+    const [index, setIndex] = useState(0);
+    const [visible, setVisible] = useState(true);
+
+    useEffect(() => {
+      const timer = setInterval(() => {
+        setVisible(false);
+        setTimeout(() => {
+          setIndex(i => (i + 1) % messages.length);
+          setVisible(true);
+        }, 400);
+      }, interval);
+      return () => clearInterval(timer);
+    }, [messages, interval]);
+
+    return { message: messages[index], visible };
+  }
+
+  const LOADING_MESSAGES = [
+    "Loading document",
+    "Preparing pages",
+    "Almost there",
+  ];
+
+  export function Loader({
+    backgroundColor = "#070114",
+    textColor = "rgba(255,255,255,0.5)",
+  }: {
+    backgroundColor?: string;
+    textColor?: string;
+  }) {
+    const { message, visible } = useLoadingMessage(LOADING_MESSAGES);
+    return (
+      <div
+        className="flex h-dvh w-full flex-col items-center justify-center gap-3"
+        style={{ backgroundColor }}
+      >
+        <div className="w-7 h-7 rounded-full border-2 border-white/10 border-t-white animate-spin" />
+        <span
+          className="text-sm tracking-wide transition-opacity duration-400"
+          style={{ opacity: visible ? 1 : 0, color: textColor }}
+        >
+          {message}
+        </span>
+      </div>
+    );
+  }
+  export default function PDFViewer({
+    url,
+    name,
+    className,
+    height = "100dvh",
+    hideControls = false,
+    backgroundColor,
+    hideScrollbar = false,
+    isolateFromTheme = true,
+    onReadingModeChange,
+  }: PdfViewerProps) {
+    const { engine, isLoading } = usePdfiumEngine();
+    const { isMobile, isSmall } = useBreakpoint();
+    const { resolvedTheme } = useTheme();
+    const [isFullscreen, setIsFullscreen] = useState(false);
+    const [isReadingMode, setIsReadingMode] = useState(false);
+    const [showReadingCoachmark, setShowReadingCoachmark] = useState(false);
+    const viewerRef = useRef<HTMLDivElement>(null);
+    const effectiveBackgroundColor =
+      backgroundColor ?? (resolvedTheme === "light" ? "#F3F5FF" : "#070114");
+    const loaderTextColor =
+      resolvedTheme === "light" ? "rgba(17,24,39,0.6)" : "rgba(255,255,255,0.5)";
+
+    const handleDownload = useCallback(async () => {
+      window.dataLayer?.push({
+        event: "pdf_download_start",
+        paper_title: name,
+        paper_url: url,
+      });
+      await downloadFile(url, `${name}.pdf`);
+    }, [url, name]);
+
+    const toggleFullscreen = useCallback(() => {
+      if (!document.fullscreenElement) {
+        void viewerRef.current?.requestFullscreen();
+      } else {
+        void document.exitFullscreen();
+      }
+    }, []);
+
+    useEffect(() => {
+      const handleFullscreenChange = () =>
+        setIsFullscreen(!!document.fullscreenElement);
+      document.addEventListener("fullscreenchange", handleFullscreenChange);
+      return () => document.removeEventListener("fullscreenchange", handleFullscreenChange);
+    }, []);
+
+    const dismissReadingCoachmark = useCallback(() => {
+      setShowReadingCoachmark(false);
+      try {
+        window.localStorage.setItem("pdfReadingModeSeen", "1");
+      } catch {
+        // localStorage unavailable (private mode, etc) — coachmark just won't persist
+      }
+    }, []);
+
+    const toggleReadingMode = useCallback(() => {
+      setIsReadingMode((r) => {
+        const next = !r;
+        onReadingModeChange?.(next);
+        return next;
+      });
+      dismissReadingCoachmark();
+    }, [dismissReadingCoachmark, onReadingModeChange]);
+
+    useEffect(() => {
+      try {
+        if (!window.localStorage.getItem("pdfReadingModeSeen")) {
+          setShowReadingCoachmark(true);
+        }
+      } catch {
+        // ignore
+      }
+    }, []);
+
+    useEffect(() => {
+      if (!isReadingMode) return;
+      const prevOverflow = document.body.style.overflow;
+      document.body.style.overflow = "hidden";
+      return () => {
+        document.body.style.overflow = prevOverflow;
+      };
+    }, [isReadingMode]);
+
+    useEffect(() => {
+      const handleKeydown = (e: KeyboardEvent) => {
+        const target = e.target as HTMLElement | null;
+        if (target && ["INPUT", "TEXTAREA"].includes(target.tagName)) return;
+
+        if (e.key === "r" || e.key === "R") {
+          toggleReadingMode();
+        } else if (e.key === "Escape" && isReadingMode) {
+          setIsReadingMode(false);
+          onReadingModeChange?.(false);
+        }
+      };
+      window.addEventListener("keydown", handleKeydown);
+      return () => window.removeEventListener("keydown", handleKeydown);
+    }, [isReadingMode, toggleReadingMode, onReadingModeChange]);
+
+    const plugins = useMemo(() => [
+      createPluginRegistration(DocumentManagerPluginPackage, {
+        initialDocuments: [{ url }],
+      }),
+      createPluginRegistration(ViewportPluginPackage),
+      createPluginRegistration(ScrollPluginPackage),
+      createPluginRegistration(RenderPluginPackage),
+      createPluginRegistration(ZoomPluginPackage, {
+        defaultZoomLevel: ZoomMode.FitPage,
+      }),
+      createPluginRegistration(ExportPluginPackage, {
+        defaultFileName: `${name}.pdf`,
+      }),
+    ], [url, name]);
+
+  if (isLoading || !engine) {
+    return (
+  <Loader
+    backgroundColor={effectiveBackgroundColor}
+    textColor={loaderTextColor}
+  />
     );
   }
 
-  return(
-    <div
-      style={{
-        top: "40%",
-        flexDirection: isSmall ? "column" : "row",
-        zIndex: 1,
-        padding: "10px 12px",
-        display: "flex",
-        gap: 16,
-        alignItems: "center",
-        alignSelf: "center",
-        width: "auto",
-        background: "#262635",
-        borderRadius: 12,
-        backdropFilter: "blur(6px)",
-      }}
-    > 
-      {isSmall ? (
-        <>
-          {pageInput}
-          <div style={{ display: "flex", flexDirection: "row", gap: 16, alignItems: "center" }}>
-            {toolSet}
-          </div>
-        </>
-      ) : (
-        <>
-          {toolSet}
-          {pageInput}
-          <ReportButton />
-        </>
-      )}
-    </div>
-  )
-});
+    return (
+      <>
+        {hideScrollbar && (
+          <style jsx global>{`
+            [data-pdf-viewer-scrollbars="hidden"] *,
+            [data-pdf-viewer-scrollbars="hidden"] {
+              scrollbar-width: none;
+              -ms-overflow-style: none;
+            }
 
-function WheelZoom({ documentId, viewerRef }: WheelZoomProps) {
-  const { provides: zoomProv } = useZoom(documentId);
-  const accumulatedDelta = useRef(0);
-  const rafId = useRef<number | null>(null);
-  const curZoom = useRef(1);
+            [data-pdf-viewer-scrollbars="hidden"] ::-webkit-scrollbar {
+              display: none;
+              width: 0;
+              height: 0;
+            }
+          `}</style>
+        )}
+        {isolateFromTheme && (
+          <style jsx global>{`
+            [data-pdf-viewer-theme="light"] {
+              color-scheme: light;
+              forced-color-adjust: none;
+            }
 
-  useEffect(() => {
-    if (!zoomProv) return;
-    curZoom.current = zoomProv.getState().currentZoomLevel;
-    const unsub = zoomProv.onZoomChange((e) => {
-      curZoom.current = e.newZoom;
-    });
-    return unsub;
-  }, [zoomProv]);
-
-  const handleWheel = useCallback(
-    (e: WheelEvent) => {
-      if (!e.ctrlKey || !zoomProv) return;
-      e.preventDefault();
-
-      const isTrackpad = Math.abs(e.deltaY) < 50;
-      const scaleFactor = isTrackpad ? 0.008 : 0.08;
-      accumulatedDelta.current += -e.deltaY * scaleFactor;
-
-      if (rafId.current !== null) cancelAnimationFrame(rafId.current);
-      rafId.current = requestAnimationFrame(() => {
-        const clamped = Math.max(-0.15, Math.min(accumulatedDelta.current, 0.15));
-
-        if (isTrackpad) {
-          const target = Math.max(0.25, Math.min(curZoom.current + clamped, 4));
-          zoomProv.requestZoom(target)
-          curZoom.current = target;
-        } else {
-          zoomProv.requestZoomBy(clamped);
-        }
-
-        accumulatedDelta.current = 0;
-        rafId.current = null;
-      });
-    },
-    [zoomProv]
-  );
-
-  useEffect(() => {
-    const viewer = viewerRef.current;
-    if (!viewer) return;
-    viewer.addEventListener("wheel", handleWheel, { passive: false });
-    return () => {
-      viewer.removeEventListener("wheel", handleWheel);
-      if (rafId.current !== null) cancelAnimationFrame(rafId.current);
-    };
-  }, [handleWheel, viewerRef]);
-
-  return null;
-}
-
-function useLoadingMessage(messages: string[], interval = 2200) {
-  const [index, setIndex] = useState(0);
-  const [visible, setVisible] = useState(true);
-
-  useEffect(() => {
-    const timer = setInterval(() => {
-      setVisible(false);
-      setTimeout(() => {
-        setIndex(i => (i + 1) % messages.length);
-        setVisible(true);
-      }, 400);
-    }, interval);
-    return () => clearInterval(timer);
-  }, [messages, interval]);
-
-  return { message: messages[index], visible };
-}
-
-const LOADING_MESSAGES = [
-  "Loading document",
-  "Preparing pages",
-  "Almost there",
-];
-
-export function Loader({
-  backgroundColor = "#070114",
-  textColor = "rgba(255,255,255,0.5)",
-}: {
-  backgroundColor?: string;
-  textColor?: string;
-}) {
-  const { message, visible } = useLoadingMessage(LOADING_MESSAGES);
-  return (
-    <div
-      className="flex h-dvh w-full flex-col items-center justify-center gap-3"
-      style={{ backgroundColor }}
-    >
-      <div className="w-7 h-7 rounded-full border-2 border-white/10 border-t-white animate-spin" />
-      <span
-        className="text-sm tracking-wide transition-opacity duration-400"
-        style={{ opacity: visible ? 1 : 0, color: textColor }}
-      >
-        {message}
-      </span>
-    </div>
-  );
-}
-export default function PDFViewer({
-  url,
-  name,
-  className,
-  height = "100dvh",
-  hideControls = false,
-  backgroundColor,
-  hideScrollbar = false,
-  isolateFromTheme = true,
-  onReadingModeChange,
-}: PdfViewerProps) {
-  const { engine, isLoading } = usePdfiumEngine();
-  const { isMobile, isSmall } = useBreakpoint();
-  const { resolvedTheme } = useTheme();
-  const [isFullscreen, setIsFullscreen] = useState(false);
-  const [isReadingMode, setIsReadingMode] = useState(false);
-  const [showReadingCoachmark, setShowReadingCoachmark] = useState(false);
-  const viewerRef = useRef<HTMLDivElement>(null);
-  const effectiveBackgroundColor =
-    backgroundColor ?? (resolvedTheme === "light" ? "#F3F5FF" : "#070114");
-  const loaderTextColor =
-    resolvedTheme === "light" ? "rgba(17,24,39,0.6)" : "rgba(255,255,255,0.5)";
-
-  const handleDownload = useCallback(async () => {
-    window.dataLayer?.push({
-      event: "pdf_download_start",
-      paper_title: name,
-      paper_url: url,
-    });
-    await downloadFile(url, `${name}.pdf`);
-  }, [url, name]);
-
-  const toggleFullscreen = useCallback(() => {
-    if (!document.fullscreenElement) {
-      void viewerRef.current?.requestFullscreen();
-    } else {
-      void document.exitFullscreen();
-    }
-  }, []);
-
-  useEffect(() => {
-    const handleFullscreenChange = () =>
-      setIsFullscreen(!!document.fullscreenElement);
-    document.addEventListener("fullscreenchange", handleFullscreenChange);
-    return () => document.removeEventListener("fullscreenchange", handleFullscreenChange);
-  }, []);
-
-  const dismissReadingCoachmark = useCallback(() => {
-    setShowReadingCoachmark(false);
-    try {
-      window.localStorage.setItem("pdfReadingModeSeen", "1");
-    } catch {
-      // localStorage unavailable (private mode, etc) — coachmark just won't persist
-    }
-  }, []);
-
-  const toggleReadingMode = useCallback(() => {
-    setIsReadingMode((r) => {
-      const next = !r;
-      onReadingModeChange?.(next);
-      return next;
-    });
-    dismissReadingCoachmark();
-  }, [dismissReadingCoachmark, onReadingModeChange]);
-
-  useEffect(() => {
-    try {
-      if (!window.localStorage.getItem("pdfReadingModeSeen")) {
-        setShowReadingCoachmark(true);
-      }
-    } catch {
-      // ignore
-    }
-  }, []);
-
-  useEffect(() => {
-    if (!isReadingMode) return;
-    const prevOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
-    return () => {
-      document.body.style.overflow = prevOverflow;
-    };
-  }, [isReadingMode]);
-
-  useEffect(() => {
-    const handleKeydown = (e: KeyboardEvent) => {
-      const target = e.target as HTMLElement | null;
-      if (target && ["INPUT", "TEXTAREA"].includes(target.tagName)) return;
-
-      if (e.key === "r" || e.key === "R") {
-        toggleReadingMode();
-      } else if (e.key === "Escape" && isReadingMode) {
-        setIsReadingMode(false);
-        onReadingModeChange?.(false);
-      }
-    };
-    window.addEventListener("keydown", handleKeydown);
-    return () => window.removeEventListener("keydown", handleKeydown);
-  }, [isReadingMode, toggleReadingMode, onReadingModeChange]);
-
-  const plugins = useMemo(() => [
-    createPluginRegistration(DocumentManagerPluginPackage, {
-      initialDocuments: [{ url }],
-    }),
-    createPluginRegistration(ViewportPluginPackage),
-    createPluginRegistration(ScrollPluginPackage),
-    createPluginRegistration(RenderPluginPackage),
-    createPluginRegistration(ZoomPluginPackage, {
-      defaultZoomLevel: ZoomMode.FitPage,
-    }),
-    createPluginRegistration(ExportPluginPackage, {
-      defaultFileName: `${name}.pdf`,
-    }),
-  ], [url, name]);
-
-if (isLoading || !engine) {
-  return (
-<Loader
-  backgroundColor={effectiveBackgroundColor}
-  textColor={loaderTextColor}
-/>
-  );
-}
-
-  return (
-    <>
-      {hideScrollbar && (
-        <style jsx global>{`
-          [data-pdf-viewer-scrollbars="hidden"] *,
-          [data-pdf-viewer-scrollbars="hidden"] {
-            scrollbar-width: none;
-            -ms-overflow-style: none;
-          }
-
-          [data-pdf-viewer-scrollbars="hidden"] ::-webkit-scrollbar {
-            display: none;
-            width: 0;
-            height: 0;
-          }
-        `}</style>
-      )}
-      {isolateFromTheme && (
-        <style jsx global>{`
-          [data-pdf-viewer-theme="light"] {
-            color-scheme: light;
-            forced-color-adjust: none;
-          }
-
-          [data-pdf-viewer-theme="light"] canvas,
-          [data-pdf-viewer-theme="light"] img,
-          [data-pdf-viewer-theme="light"] svg {
-            filter: none !important;
-            forced-color-adjust: none;
-          }
-        `}</style>
-      )}
-      <div
-        ref={viewerRef}
-        data-pdf-viewer-theme={isolateFromTheme ? "light" : "inherited"}
-        data-pdf-viewer-scrollbars={hideScrollbar ? "hidden" : "visible"}
-        className={className}
-        style={{
-          height: isReadingMode ? "100dvh" : height,
-          width: "100%",
-          position: isReadingMode ? "fixed" : "relative",
-          top: isReadingMode ? 0 : undefined,
-          left: isReadingMode ? 0 : undefined,
-          right: isReadingMode ? 0 : undefined,
-          bottom: isReadingMode ? 0 : undefined,
-          zIndex: isReadingMode ? 999 : undefined,
-          backgroundColor: effectiveBackgroundColor,
-          display: "flex",
-          flexDirection: "column",
-          colorScheme: isolateFromTheme ? "light" : undefined,
-          forcedColorAdjust: isolateFromTheme ? "none" : undefined,
-          transition: "height 0.2s ease",
-        }}
-      >
-        <EmbedPDF engine={engine} plugins={plugins}>
-        {({ activeDocumentId }) =>
-          activeDocumentId && (
-            <>
-              <WheelZoom documentId={activeDocumentId} viewerRef={viewerRef} />
-              {!hideControls && (isMobile && !isFullscreen) && 
-              <Controls
-                documentId={activeDocumentId}
-                toggleFullscreen={toggleFullscreen}
-                isFullscreen={isFullscreen}
-                onDownload={handleDownload}
-                forceMobile={true}
-                isMobile={isMobile}
-                isSmall={isSmall}
-                viewerRef={viewerRef}
-                isReadingMode={isReadingMode}
-                toggleReadingMode={toggleReadingMode}
-                showReadingCoachmark={showReadingCoachmark}
-                dismissReadingCoachmark={dismissReadingCoachmark}
-              />}
-              <DocumentContent documentId={activeDocumentId}>
-                {({ isLoaded }) => (
-                  <>
-                    <div
-                      className="absolute inset-0 z-50 flex items-center justify-center bg-[#070114]"
-                      style={{
-                      opacity: isLoaded ? 0 : 1,
-                      pointerEvents: isLoaded ? "none" : "auto",
-                      transition: "opacity 0.3s",
-                      backgroundColor: effectiveBackgroundColor,
-                      }}
-                    >
-                      <Loader
-                        backgroundColor={effectiveBackgroundColor}
-                        textColor={loaderTextColor}
-                      />
-                    </div>
-                    <Viewport
-                      documentId={activeDocumentId}
-                      style={{
-                        backgroundColor: effectiveBackgroundColor,
-                        visibility: isLoaded ? "visible" : "hidden",
-                      }}
-                    >
-                      <Scroller
-                        documentId={activeDocumentId}
-                        renderPage={({ width, height, pageIndex }) => (
-                          <div
-                            style={{ width, height }}
-                            onClick={(e) => e.stopPropagation()}
-                          >
-                            <RenderLayer documentId={activeDocumentId} pageIndex={pageIndex} />
-                          </div>
-                        )}
-                      />
-                    </Viewport>
-                  </>
-                )}
-              </DocumentContent>
-                  
-              {!hideControls && (!isMobile || isFullscreen) && (
+            [data-pdf-viewer-theme="light"] canvas,
+            [data-pdf-viewer-theme="light"] img,
+            [data-pdf-viewer-theme="light"] svg {
+              filter: none !important;
+              forced-color-adjust: none;
+            }
+          `}</style>
+        )}
+        <div
+          ref={viewerRef}
+          data-pdf-viewer-theme={isolateFromTheme ? "light" : "inherited"}
+          data-pdf-viewer-scrollbars={hideScrollbar ? "hidden" : "visible"}
+          className={className}
+          style={{
+            height: isReadingMode ? "100dvh" : height,
+            width: "100%",
+            position: isReadingMode ? "fixed" : "relative",
+            top: isReadingMode ? 0 : undefined,
+            left: isReadingMode ? 0 : undefined,
+            right: isReadingMode ? 0 : undefined,
+            bottom: isReadingMode ? 0 : undefined,
+            zIndex: isReadingMode ? 999 : undefined,
+            backgroundColor: effectiveBackgroundColor,
+            display: "flex",
+            flexDirection: "column",
+            colorScheme: isolateFromTheme ? "light" : undefined,
+            forcedColorAdjust: isolateFromTheme ? "none" : undefined,
+            transition: "height 0.2s ease",
+          }}
+        >
+          <EmbedPDF engine={engine} plugins={plugins}>
+          {({ activeDocumentId }) =>
+            activeDocumentId && (
+              <>
+                <WheelZoom documentId={activeDocumentId} viewerRef={viewerRef} />
+                {!hideControls && (isMobile && !isFullscreen) && 
                 <Controls
                   documentId={activeDocumentId}
                   toggleFullscreen={toggleFullscreen}
                   isFullscreen={isFullscreen}
                   onDownload={handleDownload}
-                  forceMobile={false}
+                  forceMobile={true}
                   isMobile={isMobile}
                   isSmall={isSmall}
                   viewerRef={viewerRef}
@@ -701,13 +646,68 @@ if (isLoading || !engine) {
                   toggleReadingMode={toggleReadingMode}
                   showReadingCoachmark={showReadingCoachmark}
                   dismissReadingCoachmark={dismissReadingCoachmark}
-                />
-              )}
-            </>
-          )
-        }
-        </EmbedPDF>
-      </div>
-    </>
-  );
-}
+                />}
+                <DocumentContent documentId={activeDocumentId}>
+                  {({ isLoaded }) => (
+                    <>
+                      <div
+                        className="absolute inset-0 z-50 flex items-center justify-center bg-[#070114]"
+                        style={{
+                        opacity: isLoaded ? 0 : 1,
+                        pointerEvents: isLoaded ? "none" : "auto",
+                        transition: "opacity 0.3s",
+                        backgroundColor: effectiveBackgroundColor,
+                        }}
+                      >
+                        <Loader
+                          backgroundColor={effectiveBackgroundColor}
+                          textColor={loaderTextColor}
+                        />
+                      </div>
+                      <Viewport
+                        documentId={activeDocumentId}
+                        style={{
+                          backgroundColor: effectiveBackgroundColor,
+                          visibility: isLoaded ? "visible" : "hidden",
+                        }}
+                      >
+                        <Scroller
+                          documentId={activeDocumentId}
+                          renderPage={({ width, height, pageIndex }) => (
+                            <div
+                              style={{ width, height }}
+                              onClick={(e) => e.stopPropagation()}
+                            >
+                              <RenderLayer documentId={activeDocumentId} pageIndex={pageIndex} />
+                            </div>
+                          )}
+                        />
+                      </Viewport>
+                    </>
+                  )}
+                </DocumentContent>
+                    
+                {!hideControls && (!isMobile || isFullscreen) && (
+                  <Controls
+                    documentId={activeDocumentId}
+                    toggleFullscreen={toggleFullscreen}
+                    isFullscreen={isFullscreen}
+                    onDownload={handleDownload}
+                    forceMobile={false}
+                    isMobile={isMobile}
+                    isSmall={isSmall}
+                    viewerRef={viewerRef}
+                    isReadingMode={isReadingMode}
+                    toggleReadingMode={toggleReadingMode}
+                    showReadingCoachmark={showReadingCoachmark}
+                    dismissReadingCoachmark={dismissReadingCoachmark}
+                  />
+                )}
+              </>
+            )
+          }
+          </EmbedPDF>
+        </div>
+      </>
+    );
+  }

--- a/src/components/ui/dropdown-menu.tsx
+++ b/src/components/ui/dropdown-menu.tsx
@@ -87,7 +87,7 @@ const DropdownMenuItem = React.forwardRef<
   <DropdownMenuPrimitive.Item
     ref={ref}
     className={cn(
-  "relative flex cursor-default select-none items-center gap-2 rounded-xl px-2 py-1.5 text-sm outline-none transition-colors hover:bg-[#1F2A3D] focus:bg-[#1F2A3D] text-white data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
+  "relative flex cursor-default select-none items-center gap-2 rounded-xl px-2 py-1.5 text-sm text-black outline-none transition-colors hover:bg-black/[0.06] focus:bg-black/[0.06] dark:text-white dark:hover:bg-[#1F2A3D] dark:focus:bg-[#1F2A3D] data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&>svg]:size-4 [&>svg]:shrink-0",
   inset && "pl-8",
   className,
 )}

--- a/src/components/ui/sorting.tsx
+++ b/src/components/ui/sorting.tsx
@@ -40,7 +40,7 @@ const SortComponent: React.FC<SortComponentProps> = ({
       <DropdownMenuTrigger asChild>
         <Button
           variant="outline"
-          className="flex h-10 gap-2 rounded-xl border-2 border-[#6536c1] bg-white/70 font-sans font-semibold text-[#6536c1] transition-colors hover:bg-[#6536c1]/10 hover:text-[#6536c1] dark:border-[#8b6cff] dark:bg-[#070114] dark:text-[#a98cff] dark:hover:border-[#a98cff] dark:hover:bg-[#6536c1]/20"
+         className="flex h-10 gap-2 rounded-full border-2 border-black bg-white font-sans font-semibold text-black transition-colors hover:bg-slate-800 hover:text-white dark:border-[#434dba] dark:bg-[#070114] dark:text-white dark:hover:border-white dark:hover:bg-slate-900"
         >
           {getSortIcon()}
           <span className="hidden sm:inline">{getSortLabel()}</span>

--- a/src/components/ui/sorting.tsx
+++ b/src/components/ui/sorting.tsx
@@ -40,7 +40,7 @@ const SortComponent: React.FC<SortComponentProps> = ({
       <DropdownMenuTrigger asChild>
         <Button
           variant="outline"
-          className="flex gap-2 border-2 border-black bg-white font-sans font-semibold hover:bg-slate-800 hover:text-white dark:border-[#434dba] dark:bg-[#070114] dark:text-white dark:hover:border-white dark:hover:bg-slate-900"
+          className="flex h-10 gap-2 rounded-xl border-2 border-[#6536c1] bg-white/70 font-sans font-semibold text-[#6536c1] transition-colors hover:bg-[#6536c1]/10 hover:text-[#6536c1] dark:border-[#8b6cff] dark:bg-[#070114] dark:text-[#a98cff] dark:hover:border-[#a98cff] dark:hover:bg-[#6536c1]/20"
         >
           {getSortIcon()}
           <span className="hidden sm:inline">{getSortLabel()}</span>

--- a/src/context/filterContext.tsx
+++ b/src/context/filterContext.tsx
@@ -308,6 +308,7 @@ export const FilterProvider: React.FC<FilterProviderProps> = ({
       papersPerPage,
       paginatedPapers,
       totalPages,
+      isDownloading,
     }),
     [
       selectedExams,
@@ -326,9 +327,9 @@ export const FilterProvider: React.FC<FilterProviderProps> = ({
       papersPerPage,
       paginatedPapers,
       totalPages,
+      isDownloading,
     ],
   );
-    isDownloading,
 
   const actionsValue: FilterActions = useMemo(
     () => ({

--- a/src/context/filterContext.tsx
+++ b/src/context/filterContext.tsx
@@ -38,6 +38,7 @@ interface FilterState {
 
   paginatedPapers: IPaper[];
   totalPages: number;
+  isDownloading: boolean;
 }
 
 interface FilterActions {
@@ -108,6 +109,7 @@ export const FilterProvider: React.FC<FilterProviderProps> = ({
   const [appliedFilters, setAppliedFilters] = useState<boolean>(false);
   const [currentPage, setCurrentPage] = useState(1);
   const [papersPerPage] = useState(12);
+  const [isDownloading, setIsDownloading] = useState<boolean>(false);
 
   const filtersNotPulled = useCallback(() => {
     setFiltersPulled(false);
@@ -145,50 +147,84 @@ export const FilterProvider: React.FC<FilterProviderProps> = ({
       toast.error("No papers selected for download.");
       return;
     }
+    if (isDownloading) return;
 
-    const zip = new JSZip();
-    const uniquePapers = Array.from(
-      new Set(selectedPapers.map((paper) => paper._id)),
-    ).map((id) => selectedPapers.find((paper) => paper._id === id)) as IPaper[];
+    setIsDownloading(true);
+    const toastId = toast.loading(
+      `Preparing ${selectedPapers.length} paper${selectedPapers.length > 1 ? "s" : ""} for download…`,
+    );
 
-    await Promise.all(
-       uniquePapers.map(async (paper) => {
-        try {
-          const response = await fetch(getSecureUrl(paper.file_url));
-          if (!response.ok) {
-            throw new Error(`HTTP ${response.status}`);
-          }
-          const blob = await response.blob();
-          const filename = generateFileName(paper);
-          zip.file(filename, blob);
+    try {
+      const zip = new JSZip();
+      const uniquePapers = Array.from(
+        new Set(selectedPapers.map((paper) => paper._id)),
+      ).map((id) => selectedPapers.find((paper) => paper._id === id)) as IPaper[];
+
+      let failedCount = 0;
+
+      await Promise.all(
+        uniquePapers.map(async (paper) => {
+          try {
+            const response = await fetch(getSecureUrl(paper.file_url));
+            if (!response.ok) {
+              throw new Error(`HTTP ${response.status}`);
+            }
+            const blob = await response.blob();
+            const filename = generateFileName(paper);
+            zip.file(filename, blob);
           } catch (err) {
+            failedCount += 1;
             console.error(`Failed to fetch ${paper.file_url}`, err);
           }
         }),
-    );
+      );
 
-    function getDownloadName(
-      params: ReadonlyURLSearchParams,
-      key: string,
-      fallback = "download",
-    ): string {
-      const value = params.get(key);
-      if (!value) return fallback;
-      return value.split(" [")[0]?.trim() ?? fallback;
+      if (failedCount === uniquePapers.length) {
+        toast.error("Couldn't prepare the download. Please try again.", {
+          id: toastId,
+        });
+        return;
+      }
+
+      function getDownloadName(
+        params: ReadonlyURLSearchParams,
+        key: string,
+        fallback = "download",
+      ): string {
+        const value = params.get(key);
+        if (!value) return fallback;
+        return value.split(" [")[0]?.trim() ?? fallback;
+      }
+
+      const zipBlob = await zip.generateAsync({ type: "blob" });
+      const url = URL.createObjectURL(zipBlob);
+      const a = document.createElement("a");
+      a.href = url;
+
+      a.download = getDownloadName(searchParams, "subject");
+
+      document.body.appendChild(a);
+      a.click();
+      a.remove();
+      URL.revokeObjectURL(url);
+
+      if (failedCount > 0) {
+        toast.success(
+          `Downloaded ${uniquePapers.length - failedCount} of ${uniquePapers.length} papers (${failedCount} failed).`,
+          { id: toastId },
+        );
+      } else {
+        toast.success("Download ready!", { id: toastId });
+      }
+    } catch (err) {
+      console.error("Failed to prepare zip", err);
+      toast.error("Something went wrong while zipping your files.", {
+        id: toastId,
+      });
+    } finally {
+      setIsDownloading(false);
     }
-    const zipBlob = await zip.generateAsync({ type: "blob" });
-    const url = URL.createObjectURL(zipBlob);
-    const a = document.createElement("a");
-    a.href = url;
-
-    a.download = getDownloadName(searchParams, "subject");
-
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    URL.revokeObjectURL(url);
-    toast.success("Download Initiated");
-  }, [searchParams, selectedPapers]);
+  }, [searchParams, selectedPapers, isDownloading]);
 
   const handleApplyFilters = useCallback(
     (
@@ -292,6 +328,7 @@ export const FilterProvider: React.FC<FilterProviderProps> = ({
       totalPages,
     ],
   );
+    isDownloading,
 
   const actionsValue: FilterActions = useMemo(
     () => ({

--- a/src/db/upcoming-slot.ts
+++ b/src/db/upcoming-slot.ts
@@ -5,7 +5,7 @@ const upcomingSlotSchema = new Schema<IUpcomingSlot>({
   slot: { type: String, required: true, unique: true },
   lastSyncedDate: { type: String },
   syncMode: {
-    type: String,
+    type: String, 
     enum: ["CAT", "FAT"],
     default: "CAT",
   },

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -19,7 +19,7 @@
 
 @layer base {
   :root {
-    --background: 0 0% 100%;
+    --background: 233 60% 98%;
     --foreground: 224 71.4% 4.1%;
     --card: 0 0% 100%;
     --card-foreground: 224 71.4% 4.1%;
@@ -27,16 +27,16 @@
     --popover-foreground: 224 71.4% 4.1%;
     --primary: 262.1 83.3% 57.8%;
     --primary-foreground: 210 20% 98%;
-    --secondary: 220 14.3% 95.9%;
+    --secondary: 233 45% 95%;
     --secondary-foreground: 220.9 39.3% 11%;
-    --muted: 220 14.3% 95.9%;
+    --muted: 233 35% 95%;
     --muted-foreground: 220 8.9% 46.1%;
-    --accent: 220 14.3% 95.9%;
+    --accent: 233 50% 94%;
     --accent-foreground: 220.9 39.3% 11%;
     --destructive: 0 84.2% 60.2%;
     --destructive-foreground: 210 20% 98%;
-    --border: 220 13% 91%;
-    --input: 220 13% 91%;
+    --border: 233 30% 90%;
+    --input: 233 30% 90%;
     --ring: 262.1 83.3% 57.8%;
     --radius: 0.5rem;
     --chart-1: 12 76% 61%;
@@ -130,13 +130,13 @@
 }
 
 ::-webkit-scrollbar-track {
-  background: #ffffff;
+  background: #f3f5ff;
   border-radius: 0.6rem;
   z-index: -99;
 }
 
 ::-webkit-scrollbar-thumb {
-  background: #929292;
+  background: #b9bde0;
   border-radius: 1rem;
 }
 


### PR DESCRIPTION
## 📌 Purpose

Improve the overall user experience across the PDF viewer and paper catalogue, with a focus on Reading Mode, light-mode UI consistency, bulk downloads, and clearer loading/feedback states.

##  Showcase

- PDF Reading Mode now works as a viewport-level overlay.
- Improved light-mode UI and dropdown readability.
- Improved Select All / Deselect All and Download Selected interactions.
- Added clear loading feedback while preparing downloads.

##  Changes

###  PDF Viewer / Reading Mode

- Added/improved Reading Mode with a dedicated book icon.
- Reading Mode now covers the browser viewport using a fixed overlay.
- The banner/navbar underneath is automatically covered while Reading Mode is active.
- Added body scroll locking while Reading Mode is active.
- Reading Mode respects the browser viewport, including split-screen/snapped windows.
- Reading Mode does not use the browser's native Fullscreen API.
- Added visual feedback/coachmark for the new Reading Mode feature.
- Added keyboard shortcut support for Reading Mode.

###  Light Mode UI/UX

- Fixed white text appearing on light dropdown backgrounds.
- Improved dropdown readability in light mode.
- Updated hover/focus states for better contrast.
- Improved consistency between light and dark mode controls.

###  Catalogue Selection & Downloads

- Improved Select All / Deselect All behaviour.
- Added selected-paper count to the Download button.
- Improved Download Selected button styling and interaction.
- Download button is disabled when no papers are selected.
- Added loading state while the ZIP is being prepared.
- Added spinner and `Preparing zip...` feedback during downloads.
- Prevented duplicate download actions while a download is in progress.
- Improved download error/partial-download feedback.
- Improved overall bulk-selection and download UX.

##  Additional Notes

- Changes were tested locally before pushing.
- Reading Mode is implemented as a CSS viewport overlay rather than native browser fullscreen.
- PR targets the `staging` branch.