### PR TITLE
Add school information to papers

### DIFF
--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -100,6 +100,7 @@ const Card = ({ paper, onSelect, isSelected, isShow=true }: CardProps) => {
                 <Capsule>{paper.slot}</Capsule>
                 <Capsule>{paper.year}</Capsule>
                 <Capsule>{paper.semester}</Capsule>
+                {paper.school && <Capsule>{paper.school}</Capsule>}
               </div>
             </div>
           </div>

--- a/src/db/papers.ts
+++ b/src/db/papers.ts
@@ -75,7 +75,7 @@ const paperSchema = new Schema<IPaper>({
   },
   school: {
     type: String,
-    enum: ["SCOPE", "SITE", "SENSE", "SMEC", "SCE", "SELECT", "SAS", "SSL", "VITBS", "SBST"],
+    enum: ["SCOPE","SITE","SENSE","SMEC","SCE","SELECT","SAS","SSL","VITBS","SBST","SCORE","SCHEME","SHINE","V-SIGN","V-SMART","V-SPARC","VAIAL","HOT"],
   },
   answer_key_included: { type: Boolean, default: false },
 });

--- a/src/db/papers.ts
+++ b/src/db/papers.ts
@@ -31,6 +31,10 @@ const adminSchema = new Schema<IAdminPaper>({
       "Mauritius",
     ],
   },
+  school: {
+    type: String || null,
+    enum: ["SCOPE", "SITE", "SENSE", "SMEC", "SCE", "SELECT", "SAS", "SSL", "VITBS", "SBST","SCORE"],
+  },
   answer_key_included: { type: Boolean || null, default: false },
   is_selected: { type: Boolean, default: false },
   ambiguous_tags: { type: [String], default: [] },
@@ -68,6 +72,10 @@ const paperSchema = new Schema<IPaper>({
       "Mauritius",
     ],
     required: true,
+  },
+  school: {
+    type: String,
+    enum: ["SCOPE", "SITE", "SENSE", "SMEC", "SCE", "SELECT", "SAS", "SSL", "VITBS", "SBST"],
   },
   answer_key_included: { type: Boolean, default: false },
 });

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -2,8 +2,6 @@ import { type mongo } from "mongoose";
 
 export interface IUpcomingSlot {
   slot: string;
-  lastSyncedDate?: string;
-  syncMode?: "CAT" | "FAT";
 }
 
 export interface IUpcomingSubject {
@@ -17,6 +15,7 @@ export interface PaperResponse {
   year: string;
   slot: string;
   exam: string;
+  school?: string;
 }
 
 export interface IAdminPaper {
@@ -39,6 +38,18 @@ export interface IAdminPaper {
     | "Bhopal"
     | "Bangalore"
     | "Mauritius"
+    | null;
+  school?:
+    | "SCOPE"
+    | "SITE"
+    | "SENSE"
+    | "SMEC"
+    | "SCE"
+    | "SELECT"
+    | "SAS"
+    | "SSL"
+    | "VITBS"
+    | "SBST"
     | null;
   answer_key_included?: boolean | null;
   is_selected?: boolean;
@@ -94,6 +105,17 @@ export interface IPaper {
     | "Bhopal"
     | "Bangalore"
     | "Mauritius";
+  school?:
+    | "SCOPE"
+    | "SITE"
+    | "SENSE"
+    | "SMEC"
+    | "SCE"
+    | "SELECT"
+    | "SAS"
+    | "SSL"
+    | "VITBS"
+    | "SBST";
   slot: string;
   subject: string;
   year: string;

--- a/src/interface.ts
+++ b/src/interface.ts
@@ -2,6 +2,8 @@ import { type mongo } from "mongoose";
 
 export interface IUpcomingSlot {
   slot: string;
+  lastSyncedDate?: string;
+  syncMode?: "CAT" | "FAT";
 }
 
 export interface IUpcomingSubject {


### PR DESCRIPTION
## 📌 Purpose

Add School information to papers so that papers can be associated with their respective schools and displayed consistently in the catalogue.

## 🔧 Changes

- Added `school` to the paper schema.
- Added `school` to the paper interface.
- Added School information to paper cards.
- Displayed the School as a capsule on paper cards.
- School is displayed only when a value is available.
- Kept the CodeChef paper model aligned with the School field added to the admin workflow.

## ➕ Additional Notes

- School information is optional.
- This PR contains only the School field changes.
- PDF Viewer changes are kept in a separate PR.
- PR targets `staging`.