### PR TITLE
Add useMemo/useCallback to context providers, fix broken react depend…

### DIFF
--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "prettier": "^3.5.3",
     "prettier-plugin-tailwindcss": "^0.6.11",
     "raw-loader": "^4.0.2",
-    "react": "link:@embedpdf/plugin-viewport/react",
+    "react": "^18.3.1",
     "react-beautiful-dnd": "^13.1.1",
     "react-dom": "^18.3.1",
     "react-dropzone": "^14.3.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -171,7 +171,7 @@ importers:
         specifier: ^4.0.2
         version: 4.0.2(webpack@5.102.0)
       react:
-        specifier: link:@embedpdf/plugin-viewport/react
+        specifier: ^18.3.1
         version: 18.3.1
       react-beautiful-dnd:
         specifier: ^13.1.1
@@ -5871,8 +5871,8 @@ snapshots:
       '@typescript-eslint/parser': 8.45.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
       eslint-plugin-jsx-a11y: 6.10.2(eslint@8.57.1)
       eslint-plugin-react: 7.37.5(eslint@8.57.1)
       eslint-plugin-react-hooks: 5.0.0-canary-7118f5dd7-20230705(eslint@8.57.1)
@@ -5891,7 +5891,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -5902,22 +5902,22 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.45.0(eslint@8.57.1)(typescript@5.9.3)
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1)
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@8.57.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -5928,7 +5928,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 8.57.1
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint@8.57.1))(eslint@8.57.1))(eslint@8.57.1)
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.45.0(eslint@8.57.1)(typescript@5.9.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@8.57.1))(eslint@8.57.1)
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3

--- a/src/components/Card.tsx
+++ b/src/components/Card.tsx
@@ -28,6 +28,17 @@ interface CardProps {
 const Card = ({ paper, onSelect, isSelected, isShow=true }: CardProps) => {
   const [previewOpen, setPreviewOpen] = React.useState(false);
 
+  const paperContextValue = React.useMemo(
+    () => ({
+      paperId: paper._id,
+      subject: paper.subject,
+      exam: paper.exam,
+      slot: paper.slot,
+      year: paper.year,
+    }),
+    [paper._id, paper.subject, paper.exam, paper.slot, paper.year],
+  );
+
   React.useEffect(() => {
     if (!previewOpen) return;
 
@@ -147,15 +158,7 @@ const Card = ({ paper, onSelect, isSelected, isShow=true }: CardProps) => {
             <div
               className="relative mx-auto h-full max-w-[760px]"
             >
-              <PaperProvider
-                value={{
-                  paperId: paper._id,
-                  subject: paper.subject,
-                  exam: paper.exam,
-                  slot: paper.slot,
-                  year: paper.year,
-                }}
-              >
+              <PaperProvider value={paperContextValue}>
               <button
                 className="fixed right-4 top-4 z-[60] rounded-full border border-black/10 bg-white/95 p-2 text-black shadow-md transition hover:bg-white"
                 onClick={() => setPreviewOpen(false)}

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -119,20 +119,32 @@ const Carousel = React.forwardRef<
       };
     }, [api, onSelect]);
 
+    const contextValue = React.useMemo(
+      () => ({
+        carouselRef,
+        api,
+        opts,
+        orientation:
+          orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+        scrollPrev,
+        scrollNext,
+        canScrollPrev,
+        canScrollNext,
+      }),
+      [
+        carouselRef,
+        api,
+        opts,
+        orientation,
+        scrollPrev,
+        scrollNext,
+        canScrollPrev,
+        canScrollNext,
+      ],
+    );
+
     return (
-      <CarouselContext.Provider
-        value={{
-          carouselRef,
-          api: api,
-          opts,
-          orientation:
-            orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
-          scrollPrev,
-          scrollNext,
-          canScrollPrev,
-          canScrollNext,
-        }}
-      >
+      <CarouselContext.Provider value={contextValue}>
         <div
           ref={ref}
           onKeyDownCapture={handleKeyDown}

--- a/src/context/courseContext.tsx
+++ b/src/context/courseContext.tsx
@@ -1,6 +1,13 @@
 "use client";
 
-import React, { createContext, useContext, useEffect, useState } from "react";
+import React, {
+  createContext,
+  useCallback,
+  useContext,
+  useEffect,
+  useMemo,
+  useState,
+} from "react";
 import axios from "axios";
 import {
   type ICourse,
@@ -24,7 +31,7 @@ export function CoursesProvider({ children }: { children: React.ReactNode }) {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  const fetchCourses = async () => {
+  const fetchCourses = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
@@ -56,16 +63,19 @@ export function CoursesProvider({ children }: { children: React.ReactNode }) {
     } finally {
       setLoading(false);
     }
-  };
+  }, []);
 
   useEffect(() => {
     void fetchCourses();
-  }, []);
+  }, [fetchCourses]);
+
+  const value = useMemo(
+    () => ({ courses, loading, error, refetch: fetchCourses }),
+    [courses, loading, error, fetchCourses],
+  );
 
   return (
-    <CoursesContext.Provider
-      value={{ courses, loading, error, refetch: fetchCourses }}
-    >
+    <CoursesContext.Provider value={value}>
       {children}
     </CoursesContext.Provider>
   );

--- a/src/context/filterContext.tsx
+++ b/src/context/filterContext.tsx
@@ -35,6 +35,9 @@ interface FilterState {
   filtersPulled: boolean;
   currentPage: number;
   papersPerPage: number;
+
+  paginatedPapers: IPaper[];
+  totalPages: number;
 }
 
 interface FilterActions {
@@ -68,14 +71,14 @@ interface FilterActions {
   filtersNotPulled: () => void;
   noAppliedFilters: () => void;
   closeFilters: () => void;
-
-  paginatedPapers: IPaper[];
-  totalPages: number;
 }
 
 type FilterContextType = FilterState & FilterActions;
 
-const FilterContext = createContext<FilterContextType | undefined>(undefined);
+const FilterStateContext = createContext<FilterState | undefined>(undefined);
+const FilterActionsContext = createContext<FilterActions | undefined>(
+  undefined,
+);
 
 interface FilterProviderProps {
   children: ReactNode;
@@ -162,7 +165,7 @@ export const FilterProvider: React.FC<FilterProviderProps> = ({
             console.error(`Failed to fetch ${paper.file_url}`, err);
           }
         }),
-    );   
+    );
 
     function getDownloadName(
       params: ReadonlyURLSearchParams,
@@ -251,7 +254,7 @@ export const FilterProvider: React.FC<FilterProviderProps> = ({
     [appliedFilters, filteredPapers.length, papers.length, papersPerPage],
   );
 
-  const value: FilterContextType = useMemo(
+  const stateValue: FilterState = useMemo(
     () => ({
       selectedExams,
       selectedSlots,
@@ -267,29 +270,6 @@ export const FilterProvider: React.FC<FilterProviderProps> = ({
       filtersPulled,
       currentPage,
       papersPerPage,
-
-      setSelectedExams,
-      setSelectedSlots,
-      setSelectedYears,
-      setSelectedSemesters,
-      setSelectedCampuses,
-      setSelectedAnswerKeyIncluded,
-      setPapers,
-      setFilteredPapers,
-      setFilterOptions,
-      setFiltersPulled,
-      setAppliedFilters,
-      setCurrentPage,
-
-      handleApplyFilters,
-      handleSelectPaper,
-      handleSelectAll,
-      handleDeselectAll,
-      handleDownloadSelected,
-      filtersNotPulled,
-      noAppliedFilters,
-      closeFilters,
-
       paginatedPapers,
       totalPages,
     }),
@@ -308,6 +288,25 @@ export const FilterProvider: React.FC<FilterProviderProps> = ({
       filtersPulled,
       currentPage,
       papersPerPage,
+      paginatedPapers,
+      totalPages,
+    ],
+  );
+
+  const actionsValue: FilterActions = useMemo(
+    () => ({
+      setSelectedExams,
+      setSelectedSlots,
+      setSelectedYears,
+      setSelectedSemesters,
+      setSelectedCampuses,
+      setSelectedAnswerKeyIncluded,
+      setPapers,
+      setFilteredPapers,
+      setFilterOptions,
+      setFiltersPulled,
+      setAppliedFilters,
+      setCurrentPage,
       handleApplyFilters,
       handleSelectPaper,
       handleSelectAll,
@@ -316,20 +315,46 @@ export const FilterProvider: React.FC<FilterProviderProps> = ({
       filtersNotPulled,
       noAppliedFilters,
       closeFilters,
-      paginatedPapers,
-      totalPages,
+    }),
+    [
+      handleApplyFilters,
+      handleSelectPaper,
+      handleSelectAll,
+      handleDeselectAll,
+      handleDownloadSelected,
+      filtersNotPulled,
+      noAppliedFilters,
+      closeFilters,
     ],
   );
 
   return (
-    <FilterContext.Provider value={value}>{children}</FilterContext.Provider>
+    <FilterActionsContext.Provider value={actionsValue}>
+      <FilterStateContext.Provider value={stateValue}>
+        {children}
+      </FilterStateContext.Provider>
+    </FilterActionsContext.Provider>
   );
 };
 
-export const useFilters = (): FilterContextType => {
-  const context = useContext(FilterContext);
+export const useFilterState = (): FilterState => {
+  const context = useContext(FilterStateContext);
   if (!context) {
-    throw new Error("useFilters must be used within a FilterProvider");
+    throw new Error("useFilterState must be used within a FilterProvider");
   }
   return context;
+};
+
+export const useFilterActions = (): FilterActions => {
+  const context = useContext(FilterActionsContext);
+  if (!context) {
+    throw new Error("useFilterActions must be used within a FilterProvider");
+  }
+  return context;
+};
+
+export const useFilters = (): FilterContextType => {
+  const state = useFilterState();
+  const actions = useFilterActions();
+  return useMemo(() => ({ ...state, ...actions }), [state, actions]);
 };

--- a/src/context/filterContext.tsx
+++ b/src/context/filterContext.tsx
@@ -5,6 +5,7 @@ import React, {
   useContext,
   useState,
   useCallback,
+  useMemo,
   type ReactNode,
 } from "react";
 import {
@@ -232,56 +233,93 @@ export const FilterProvider: React.FC<FilterProviderProps> = ({
     ],
   );
 
-  const paginatedPapers = filteredPapers.slice(
-    (currentPage - 1) * papersPerPage,
-    currentPage * papersPerPage,
+  const paginatedPapers = useMemo(
+    () =>
+      filteredPapers.slice(
+        (currentPage - 1) * papersPerPage,
+        currentPage * papersPerPage,
+      ),
+    [filteredPapers, currentPage, papersPerPage],
   );
 
-  const totalPages = Math.ceil(
-    (appliedFilters ? filteredPapers.length : papers.length) / papersPerPage,
+  const totalPages = useMemo(
+    () =>
+      Math.ceil(
+        (appliedFilters ? filteredPapers.length : papers.length) /
+          papersPerPage,
+      ),
+    [appliedFilters, filteredPapers.length, papers.length, papersPerPage],
   );
 
-  const value: FilterContextType = {
-    selectedExams,
-    selectedSlots,
-    selectedYears,
-    selectedSemesters,
-    selectedCampuses,
-    selectedAnswerKeyIncluded,
-    papers,
-    filteredPapers,
-    selectedPapers,
-    filterOptions,
-    appliedFilters,
-    filtersPulled,
-    currentPage,
-    papersPerPage,
+  const value: FilterContextType = useMemo(
+    () => ({
+      selectedExams,
+      selectedSlots,
+      selectedYears,
+      selectedSemesters,
+      selectedCampuses,
+      selectedAnswerKeyIncluded,
+      papers,
+      filteredPapers,
+      selectedPapers,
+      filterOptions,
+      appliedFilters,
+      filtersPulled,
+      currentPage,
+      papersPerPage,
 
-    setSelectedExams,
-    setSelectedSlots,
-    setSelectedYears,
-    setSelectedSemesters,
-    setSelectedCampuses,
-    setSelectedAnswerKeyIncluded,
-    setPapers,
-    setFilteredPapers,
-    setFilterOptions,
-    setFiltersPulled,
-    setAppliedFilters,
-    setCurrentPage,
+      setSelectedExams,
+      setSelectedSlots,
+      setSelectedYears,
+      setSelectedSemesters,
+      setSelectedCampuses,
+      setSelectedAnswerKeyIncluded,
+      setPapers,
+      setFilteredPapers,
+      setFilterOptions,
+      setFiltersPulled,
+      setAppliedFilters,
+      setCurrentPage,
 
-    handleApplyFilters,
-    handleSelectPaper,
-    handleSelectAll,
-    handleDeselectAll,
-    handleDownloadSelected,
-    filtersNotPulled,
-    noAppliedFilters,
-    closeFilters,
+      handleApplyFilters,
+      handleSelectPaper,
+      handleSelectAll,
+      handleDeselectAll,
+      handleDownloadSelected,
+      filtersNotPulled,
+      noAppliedFilters,
+      closeFilters,
 
-    paginatedPapers,
-    totalPages,
-  };
+      paginatedPapers,
+      totalPages,
+    }),
+    [
+      selectedExams,
+      selectedSlots,
+      selectedYears,
+      selectedSemesters,
+      selectedCampuses,
+      selectedAnswerKeyIncluded,
+      papers,
+      filteredPapers,
+      selectedPapers,
+      filterOptions,
+      appliedFilters,
+      filtersPulled,
+      currentPage,
+      papersPerPage,
+      handleApplyFilters,
+      handleSelectPaper,
+      handleSelectAll,
+      handleDeselectAll,
+      handleDownloadSelected,
+      filtersNotPulled,
+      noAppliedFilters,
+      closeFilters,
+      paginatedPapers,
+      totalPages,
+    ],
+  );
 
   return (
     <FilterContext.Provider value={value}>{children}</FilterContext.Provider>


### PR DESCRIPTION
## Description

Fixes #471

### Changes Made

* Memoized Provider `value` objects in:

  * `courseContext.tsx`
  * `filterContext.tsx`
  * `Card.tsx` (`PaperProvider`)
  * `carousel.tsx` (`CarouselContext`)
* Prevented unnecessary re-renders of context consumers when the Provider values have not changed.
* Fixed the `react` dependency in `package.json`, restoring it to `^18.3.1` to match `react-dom`.

### Verification

* `tsc --noEmit` ✅
* `pnpm build` ✅
* `pnpm lint` ✅

All checks pass successfully.
