### PR TITLE
Add feedback form with rate limiting

### DIFF
--- a/src/app/api/feedback/route.ts
+++ b/src/app/api/feedback/route.ts
@@ -1,0 +1,19 @@
+import { createFeedback } from "@/lib/services/feedback";
+import { success } from "@/lib/utils/response";
+import { customErrorHandler } from "@/lib/utils/error";
+
+export async function POST(req: Request) {
+  try {
+    const body = (await req.json()) as { message?: unknown; email?: unknown };
+    const newFeedback = await createFeedback(body);
+
+    return success(
+      { message: "Feedback submitted successfully!", feedback: newFeedback },
+      "Created",
+      201,
+    );
+  } catch (error) {
+    console.error("Error submitting feedback:", error);
+    return customErrorHandler(error, "Failed to submit feedback.");
+  }
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -22,6 +22,7 @@ import {
 import { useCourses } from "@/context/courseContext";
 import PinnedModal from "./ui/PinnedModal";
 import RequestModal from "./ui/RequestModal";
+import FeedbackModal from "./ui/FeedbackModal";
 import Announcement from "./ui/announcement/Announcement";
 import { getSubjectEvent, type EventData } from "@/config/events";
 
@@ -93,6 +94,12 @@ function Navbar() {
       <div className="flex h-8 items-center gap-1 rounded-full border border-[#3A3745] bg-[#e8e9ff] px-2.5 py-1 text-xs font-semibold text-gray-700 transition hover:bg-slate-50 dark:bg-black dark:text-white dark:hover:bg-[#1A1823] sm:h-9 sm:gap-2 sm:px-3.5 sm:py-1.5 sm:text-sm md:h-10 md:px-4 md:py-2 md:text-base">
         <span className="truncate">
           <RequestModal />
+        </span>
+      </div>
+
+      <div className="flex h-8 items-center gap-1 rounded-full border border-[#3A3745] bg-[#e8e9ff] px-2.5 py-1 text-xs font-semibold text-gray-700 transition hover:bg-slate-50 dark:bg-black dark:text-white dark:hover:bg-[#1A1823] sm:h-9 sm:gap-2 sm:px-3.5 sm:py-1.5 sm:text-sm md:h-10 md:px-4 md:py-2 md:text-base">
+        <span className="truncate">
+          <FeedbackModal />
         </span>
       </div>
     </>
@@ -173,6 +180,15 @@ function Navbar() {
                       <RequestModal />
                     </div>
                   </DropdownMenuItem>
+
+                  <DropdownMenuItem
+                    asChild
+                    onSelect={(e) => e.preventDefault()}
+                  >
+                    <div className="flex w-full items-center gap-3 rounded-lg px-3 py-1 transition hover:bg-[#1A1823] hover:text-white">
+                      <FeedbackModal />
+                    </div>
+                  </DropdownMenuItem>
                 </DropdownMenuContent>
               </DropdownMenu>
             </div>
@@ -209,6 +225,12 @@ function Navbar() {
                       onSelect={(e) => e.preventDefault()}
                     >
                       <RequestModal />
+                    </DropdownMenuItem>
+                    <DropdownMenuItem
+                      asChild
+                      onSelect={(e) => e.preventDefault()}
+                    >
+                      <FeedbackModal />
                     </DropdownMenuItem>
                   </DropdownMenuContent>
                 </DropdownMenu>

--- a/src/components/ui/FeedbackModal.tsx
+++ b/src/components/ui/FeedbackModal.tsx
@@ -1,0 +1,110 @@
+"use client";
+
+import React from 'react'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from "@/components/ui/dialog"
+import { MessageSquare } from 'lucide-react'
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { useState } from 'react';
+import { Button } from "@/components/ui/button";
+import axios from 'axios';
+import toast from 'react-hot-toast';
+
+const FeedbackModal = ({section = "navbar"} : {section? : string}) => {
+    const [open, setOpen] = useState(false);
+    const [message, setMessage] = useState("");
+    const [email, setEmail] = useState("");
+
+    const resetModal = () => {
+        setMessage("");
+        setEmail("");
+    };
+
+    const handleSubmit = async () => {
+        if (!message.trim()) {
+            toast.error("Please enter your feedback before submitting.");
+            return;
+        }
+
+        try {
+            await toast.promise(
+                axios.post("/api/feedback", {
+                    message: message.trim(),
+                    email: email.trim() || undefined,
+                }),
+                {
+                    loading: "Submitting your feedback...",
+                    success: "Thanks for your feedback!",
+                    error: "Failed to submit your feedback. Please try again later.",
+                },
+            );
+
+            setOpen(false);
+        } catch (error) {
+            console.error("Error submitting feedback:", error);
+        }
+    };
+
+    return (
+    <Dialog
+    open={open} onOpenChange={(isOpen) => {
+    setOpen(isOpen);
+    if (isOpen) resetModal();
+    }}>
+        {section === "navbar" ?
+        <DialogTrigger className="flex w-full items-center gap-2.5 bg-transparent hover:bg-transparent focus:bg-transparent text-left cursor-pointer border-0 shadow-none outline-none">
+            <MessageSquare className="h-4 w-4"/>
+            <span className="text-xs font-medium">Feedback</span>
+        </DialogTrigger> :
+        <DialogTrigger className='underline text-[#562EE7] dark:text-[#A47DE5] '>
+            <span className="font-medium">give feedback.</span>
+        </DialogTrigger>
+        }
+        <DialogContent className='bg-[#F3F5FF] dark:bg-[#070114] border-[#3A3745] items-start'>
+            <DialogHeader>
+                <DialogTitle>Share Feedback</DialogTitle>
+                <DialogDescription>
+                    Spotted a bug or have an idea to make this better? Let us know below — it only takes a few seconds.
+                </DialogDescription>
+            </DialogHeader>
+            <div className="w-full text-end">
+                <div className="mx-auto mb-4 max-w-xl font-play">
+                    <Textarea
+                        value={message}
+                        onChange={(e) => setMessage(e.target.value)}
+                        placeholder="What's on your mind?"
+                        rows={4}
+                        className="text-md rounded-2xl bg-[#B2B8FF] px-4 py-3 font-play tracking-wider text-black shadow-sm ring-0 placeholder:text-black focus:outline-none focus:ring-0 dark:bg-[#7480FF66] dark:text-white placeholder:dark:text-white"
+                    />
+                </div>
+
+                <div className="mx-auto mb-8 max-w-xl font-play">
+                    <Input
+                        type="email"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        placeholder="Email (optional, if you'd like a reply)"
+                        className="text-md rounded-2xl bg-[#B2B8FF] px-4 py-6 font-play tracking-wider text-black shadow-sm ring-0 placeholder:text-black focus:outline-none focus:ring-0 dark:bg-[#7480FF66] dark:text-white placeholder:dark:text-white"
+                    />
+                </div>
+
+                <Button
+                    className="rounded-md px-8 py-3 hover:opacity-80 bg-[#B2B8FF] text-black dark:border-[#36266D] dark:bg-[#7480ff9d] dark:text-white"
+                    onClick={handleSubmit}
+                >
+                    Submit
+                </Button>
+            </div>
+        </DialogContent>
+    </Dialog>
+    )
+}
+
+export default FeedbackModal

--- a/src/components/ui/textarea.tsx
+++ b/src/components/ui/textarea.tsx
@@ -1,0 +1,23 @@
+import * as React from "react";
+
+import { cn } from "@/lib/utils";
+
+export type TextareaProps = React.TextareaHTMLAttributes<HTMLTextAreaElement>;
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, TextareaProps>(
+  ({ className, ...props }, ref) => {
+    return (
+      <textarea
+        className={cn(
+          "flex min-h-[100px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-sm transition-colors placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+          className,
+        )}
+        ref={ref}
+        {...props}
+      />
+    );
+  },
+);
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/src/db/feedback.ts
+++ b/src/db/feedback.ts
@@ -1,0 +1,21 @@
+import mongoose, { Schema, type Document, type Model } from "mongoose";
+
+export interface IFeedback extends Document {
+  message: string;
+  email?: string;
+  createdAt: Date;
+}
+
+const feedbackSchema = new Schema<IFeedback>({
+  message: { type: String, required: true },
+  email: { type: String },
+  createdAt: { type: Date, default: Date.now },
+});
+
+feedbackSchema.index({ createdAt: -1 });
+
+const Feedback: Model<IFeedback> =
+  mongoose.models.Feedback ??
+  mongoose.model<IFeedback>("Feedback", feedbackSchema);
+
+export default Feedback;

--- a/src/lib/services/feedback.ts
+++ b/src/lib/services/feedback.ts
@@ -1,0 +1,40 @@
+import { connectToDatabase } from "@/lib/database/mongoose";
+import Feedback from "@/db/feedback";
+import { CustomError } from "@/lib/utils/error";
+
+const MAX_MESSAGE_LENGTH = 2000;
+const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+export interface CreateFeedbackInput {
+  message?: unknown;
+  email?: unknown;
+}
+
+export async function createFeedback({ message, email }: CreateFeedbackInput) {
+  const trimmedMessage = typeof message === "string" ? message.trim() : "";
+
+  if (!trimmedMessage) {
+    throw new CustomError("Feedback message is required.", 400);
+  }
+
+  if (trimmedMessage.length > MAX_MESSAGE_LENGTH) {
+    throw new CustomError(
+      `Feedback message must be under ${MAX_MESSAGE_LENGTH} characters.`,
+      400,
+    );
+  }
+
+  let trimmedEmail: string | undefined;
+  if (typeof email === "string" && email.trim().length > 0) {
+    trimmedEmail = email.trim();
+    if (!EMAIL_REGEX.test(trimmedEmail)) {
+      throw new CustomError("Invalid email format.", 400);
+    }
+  }
+
+  await connectToDatabase();
+  return await Feedback.create({
+    message: trimmedMessage,
+    email: trimmedEmail,
+  });
+}

--- a/src/lib/utils/ratelimit.ts
+++ b/src/lib/utils/ratelimit.ts
@@ -18,3 +18,9 @@ export const subscribeRatelimit = new Ratelimit({
   redis: redis,
   limiter: Ratelimit.slidingWindow(3, "1 h"),
 });
+
+// Rate limiter for Feedback (5 requests per 15 minutes)
+export const feedbackRatelimit = new Ratelimit({
+  redis: redis,
+  limiter: Ratelimit.slidingWindow(5, "900 s"),
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -3,11 +3,12 @@ import {
   aiUploadRatelimit,
   paperRequestRatelimit,
   subscribeRatelimit,
+  feedbackRatelimit,
 } from "./lib/utils/ratelimit";
 import { failure } from "@/lib/utils/response"
 
 export const config = {
-  matcher: ["/api/upload", "/api/request", "/api/subscribe"],
+  matcher: ["/api/upload", "/api/request", "/api/subscribe", "/api/feedback"],
 };
 
 export default async function middleware(request: NextRequest) {
@@ -32,6 +33,13 @@ export default async function middleware(request: NextRequest) {
     const { success } = await subscribeRatelimit.limit(ip);
     if (!success) {
       return failure("Maximum of 3 newsletter subscriptions per hour", 429);
+    }
+  }
+
+  if (pathname === "/api/feedback") {
+    const { success } = await feedbackRatelimit.limit(ip);
+    if (!success) {
+      return failure("You can submit a maximum of 5 feedback messages every 15 minutes", 429);
     }
   }
 


### PR DESCRIPTION
Fixes #379.

- Added a Feedback modal accessible from the navbar (matches the existing Request Paper modal's structure and styling)
- New /api/feedback route, service layer, and Mongoose model — validates message (required) and email (optional, format-checked)
- Rate limited to 5 submissions per 15 minutes, reusing the existing Upstash Redis rate-limiting pattern used for paper requests and uploads

Verified with tsc --noEmit, pnpm build, and pnpm lint — all pass clean.
